### PR TITLE
refactor: decouple cluster service

### DIFF
--- a/src/slipbox_mcp/models/cluster_models.py
+++ b/src/slipbox_mcp/models/cluster_models.py
@@ -1,0 +1,33 @@
+"""Domain models and constants for cluster detection."""
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+MIN_CLUSTER_SIZE = 5
+CO_OCCURRENCE_THRESHOLD = 3
+REPORT_PATH = Path("~/.local/share/mcp/slipbox/cluster-analysis.json").expanduser()
+
+
+@dataclass
+class ClusterCandidate:
+    """A detected cluster that may need a structure note."""
+    id: str
+    suggested_title: str
+    tags: List[str]
+    notes: List[Dict[str, str]]  # [{id, title}, ...]
+    note_count: int
+    orphan_count: int
+    internal_links: int
+    density: float
+    score: float
+    newest_date: Optional[datetime] = None
+
+
+@dataclass
+class ClusterReport:
+    """Full cluster analysis report."""
+    generated_at: datetime
+    clusters: List[ClusterCandidate]
+    stats: Dict[str, Any]
+    dismissed_cluster_ids: List[str] = field(default_factory=list)

--- a/src/slipbox_mcp/services/__init__.py
+++ b/src/slipbox_mcp/services/__init__.py
@@ -1,6 +1,8 @@
 """Service layer for the Zettelkasten MCP server."""
-from slipbox_mcp.services.cluster_service import (  # noqa: F401
+from slipbox_mcp.models.cluster_models import (  # noqa: F401
     ClusterCandidate as ClusterCandidate,
     ClusterReport as ClusterReport,
+)
+from slipbox_mcp.services.cluster_service import (  # noqa: F401
     ClusterService as ClusterService,
 )

--- a/src/slipbox_mcp/services/cluster_service.py
+++ b/src/slipbox_mcp/services/cluster_service.py
@@ -23,8 +23,9 @@ logger = logging.getLogger(__name__)
 class ClusterService:
     """Service for detecting and managing knowledge clusters."""
 
-    def __init__(self, zettel_service: Optional[ZettelService] = None):
+    def __init__(self, zettel_service: Optional[ZettelService] = None, report_path: Optional[Path] = None):
         self.zettel_service = zettel_service or ZettelService()
+        self.report_path = Path(report_path) if report_path is not None else REPORT_PATH
 
     def build_tag_cooccurrence(self, notes: List[Note]) -> Dict[Tuple[str, str], int]:
         """Build matrix of tag pairs that appear together on notes."""
@@ -197,7 +198,7 @@ class ClusterService:
 
     def save_report(self, report: ClusterReport) -> Path:
         """Save cluster report to JSON file."""
-        REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        self.report_path.parent.mkdir(parents=True, exist_ok=True)
 
         data = {
             "generated_at": report.generated_at.isoformat(),
@@ -220,16 +221,16 @@ class ClusterService:
             "dismissed_cluster_ids": report.dismissed_cluster_ids
         }
 
-        REPORT_PATH.write_text(json.dumps(data, indent=2))
-        return REPORT_PATH
+        self.report_path.write_text(json.dumps(data, indent=2))
+        return self.report_path
 
     def load_report(self) -> Optional[ClusterReport]:
         """Load cluster report from JSON file."""
-        if not REPORT_PATH.exists():
+        if not self.report_path.exists():
             return None
 
         try:
-            data = json.loads(REPORT_PATH.read_text())
+            data = json.loads(self.report_path.read_text())
             return ClusterReport(
                 generated_at=datetime.fromisoformat(data["generated_at"]),
                 clusters=[

--- a/src/slipbox_mcp/services/cluster_service.py
+++ b/src/slipbox_mcp/services/cluster_service.py
@@ -168,9 +168,9 @@ class ClusterService:
         primary = sorted_tags[0].replace("-", " ").title()
         return f"{primary} Knowledge Map"
 
-    def detect_clusters(self) -> ClusterReport:
+    def detect_clusters(self, notes: Optional[List[Note]] = None) -> ClusterReport:
         """Run full cluster detection analysis."""
-        all_notes = self.zettel_service.get_all_notes()
+        all_notes = notes if notes is not None else self.zettel_service.get_all_notes()
         cooccurrence = self.build_tag_cooccurrence(all_notes)
         tag_clusters = self.find_tag_clusters(cooccurrence)
 

--- a/src/slipbox_mcp/services/cluster_service.py
+++ b/src/slipbox_mcp/services/cluster_service.py
@@ -2,44 +2,22 @@
 import json
 import logging
 from collections import defaultdict
-from dataclasses import dataclass, field
 from datetime import datetime
 from itertools import combinations
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from slipbox_mcp.models.cluster_models import (
+    CO_OCCURRENCE_THRESHOLD,
+    MIN_CLUSTER_SIZE,
+    REPORT_PATH,
+    ClusterCandidate,
+    ClusterReport,
+)
 from slipbox_mcp.models.schema import Note, NoteType
 from slipbox_mcp.services.zettel_service import ZettelService
 
 logger = logging.getLogger(__name__)
-
-MIN_CLUSTER_SIZE = 5
-CO_OCCURRENCE_THRESHOLD = 3
-REPORT_PATH = Path("~/.local/share/mcp/slipbox/cluster-analysis.json").expanduser()
-
-
-@dataclass
-class ClusterCandidate:
-    """A detected cluster that may need a structure note."""
-    id: str
-    suggested_title: str
-    tags: List[str]
-    notes: List[Dict[str, str]]  # [{id, title}, ...]
-    note_count: int
-    orphan_count: int
-    internal_links: int
-    density: float
-    score: float
-    newest_date: Optional[datetime] = None
-
-
-@dataclass
-class ClusterReport:
-    """Full cluster analysis report."""
-    generated_at: datetime
-    clusters: List[ClusterCandidate]
-    stats: Dict[str, Any]
-    dismissed_cluster_ids: List[str] = field(default_factory=list)
 
 
 class ClusterService:

--- a/tests/test_cluster_service.py
+++ b/tests/test_cluster_service.py
@@ -341,6 +341,41 @@ class TestScoreCluster:
         assert result["internal_links"] == 0, f"Expected 0 internal links, got {result['internal_links']}"
 
 
+class TestReportPath:
+    """ClusterService should support configurable report paths."""
+
+    def test_save_report_to_custom_path(self, tmp_path):
+        """save_report should use the configured report path."""
+        from datetime import datetime
+
+        service = ClusterService(report_path=tmp_path / "report.json")
+        report = ClusterReport(
+            generated_at=datetime.now(),
+            clusters=[],
+            stats={},
+            dismissed_cluster_ids=[],
+        )
+        path = service.save_report(report)
+        assert path == tmp_path / "report.json"
+        assert path.exists()
+
+    def test_load_report_from_custom_path(self, tmp_path):
+        """load_report should read from the configured report path."""
+        from datetime import datetime
+
+        service = ClusterService(report_path=tmp_path / "report.json")
+        report = ClusterReport(
+            generated_at=datetime.now(),
+            clusters=[],
+            stats={"total_notes": 0},
+            dismissed_cluster_ids=[],
+        )
+        service.save_report(report)
+        loaded = service.load_report()
+        assert loaded is not None
+        assert loaded.stats == {"total_notes": 0}
+
+
 class TestDetectClusters:
     """detect_clusters runs the full cluster detection pipeline."""
 

--- a/tests/test_cluster_service.py
+++ b/tests/test_cluster_service.py
@@ -6,6 +6,7 @@ from slipbox_mcp.models.schema import LinkType, NoteType
 from slipbox_mcp.services.cluster_service import (
     CO_OCCURRENCE_THRESHOLD,
     MIN_CLUSTER_SIZE,
+    ClusterReport,
     ClusterService,
 )
 from helpers import make_note
@@ -338,6 +339,27 @@ class TestScoreCluster:
         assert result is not None, "Score result should not be None at min cluster size"
         assert result["density"] == 0.0, f"Density should be 0.0 with no links, got {result['density']}"
         assert result["internal_links"] == 0, f"Expected 0 internal links, got {result['internal_links']}"
+
+
+class TestDetectClusters:
+    """detect_clusters runs the full cluster detection pipeline."""
+
+    def test_detect_clusters_accepts_notes_directly(self):
+        """detect_clusters should work with a plain note list."""
+        from slipbox_mcp.models.schema import Note, NoteType, Tag
+
+        service = ClusterService()
+        # Create enough notes with shared tags to form a cluster
+        notes = []
+        for i in range(6):
+            notes.append(Note(
+                title=f"Test Note {i}",
+                content=f"Content {i}",
+                note_type=NoteType.PERMANENT,
+                tags=[Tag(name="alpha"), Tag(name="beta")],
+            ))
+        report = service.detect_clusters(notes=notes)
+        assert isinstance(report, ClusterReport)
 
 
 class TestSuggestTitle:


### PR DESCRIPTION
## Summary
- `detect_clusters()` now accepts optional `notes` parameter, removing hard dependency on ZettelService
- Extract `ClusterCandidate` and `ClusterReport` to `models/cluster_models.py`
- Make `REPORT_PATH` configurable via constructor parameter

## Motivation
ClusterService is a bolt-on analysis tool with its own storage, domain models, and no reverse dependencies from core. These changes make the separation explicit and the service more testable (injectable report path, no ZettelService required for pure analysis).

## Test plan
- [x] `test_detect_clusters_accepts_notes_directly` -- works with plain note list
- [x] `test_save_report_to_custom_path` -- uses configured path
- [x] `test_load_report_from_custom_path` -- reads from configured path
- [x] Full suite: 222 passed