### PR TITLE
fix(ci): drop root privileges before running LLM evals

### DIFF
--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -19,4 +19,16 @@ jobs:
       - name: Install dependencies
         run: uv venv && uv pip install -e ".[dev]"
       - name: Run LLM evals
-        run: source .venv/bin/activate && pytest evals/llm/ -v --tb=short
+        run: |
+          set -e
+          activate_cmd="source .venv/bin/activate"
+
+          if [ "$(id -u)" -eq 0 ]; then
+            # claude CLI refuses --dangerously-skip-permissions as root.
+            # Drop to a non-root user for the eval run.
+            useradd --system --create-home --shell /bin/bash evalrunner 2>/dev/null || true
+            chown -R evalrunner:evalrunner "$PWD"
+            runuser -u evalrunner -- bash -c "$activate_cmd && pytest evals/llm/ -v --tb=short"
+          else
+            $activate_cmd && pytest evals/llm/ -v --tb=short
+          fi


### PR DESCRIPTION
The claude CLI refuses --dangerously-skip-permissions when running as
root for security reasons. The self-hosted runner executes as root,
causing all 28 LLM eval tests to fail immediately.

Detect root at runtime and drop to a dedicated evalrunner user via
runuser before launching pytest.

https://claude.ai/code/session_01TK6CQaLbqjCP4utzsG1KDx