### PR TITLE
Week 1: Polish & prepare for public release

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: jamesfishwick

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Model Context Protocol server for managing a Zettelkasten knowledge system with 
 
 ## Requirements
 
-- Python 3.11+
+- Python 3.10+
 - macOS or Linux
 
 ## Features
@@ -111,7 +111,7 @@ In Claude:
 
 ## Optional: Automatic Cluster Detection
 
-Cluster analysis scans all notes and computes similarity scores. Running it daily (6am) pre-computes results so `zk_get_cluster_report()` returns instantly. Without scheduling, cluster detection runs on-demand, which is slower for large collections.
+Cluster analysis scans all notes and computes similarity scores. Running it daily (6am) pre-computes results so `slipbox_get_cluster_report()` returns instantly. Without scheduling, cluster detection runs on-demand, which is slower for large collections.
 
 Run manually after bulk imports, major reorganization, or when you want immediate results.
 
@@ -143,7 +143,7 @@ Output saved to `~/.local/share/mcp/slipbox/cluster-analysis.json`.
 
 ## Optional: File Watcher for Auto-Indexing
 
-The MCP server maintains a database index for fast searching. Editing notes in Obsidian (or any editor) makes the database stale until you run `zk_rebuild_index`.
+The MCP server maintains a database index for fast searching. Editing notes in Obsidian (or any editor) makes the database stale until you run `slipbox_rebuild_index`.
 
 The file watcher runs as a background daemon, monitoring your notes directory and automatically rebuilding the index when `.md` files change.
 
@@ -200,45 +200,45 @@ Add the system prompt from `docs/SYSTEM_PROMPT.md` to your Claude preferences. T
 
 | Tool | Description |
 |------|-------------|
-| `zk_create_note` | Create atomic notes (fleeting/literature/permanent/structure/hub) |
-| `zk_get_note` | Retrieve note by ID or title |
-| `zk_update_note` | Update existing notes |
-| `zk_delete_note` | Delete notes |
+| `slipbox_create_note` | Create atomic notes (fleeting/literature/permanent/structure/hub) |
+| `slipbox_get_note` | Retrieve note by ID or title |
+| `slipbox_update_note` | Update existing notes |
+| `slipbox_delete_note` | Delete notes |
 
 ### Linking
 
 | Tool | Description |
 |------|-------------|
-| `zk_create_link` | Create semantic links between notes |
-| `zk_remove_link` | Remove links |
-| `zk_delete_link` | Delete a specific link (errors if link does not exist) |
-| `zk_get_linked_notes` | Get notes linked to/from a note |
+| `slipbox_create_link` | Create semantic links between notes |
+| `slipbox_remove_link` | Remove links |
+| `slipbox_delete_link` | Delete a specific link (errors if link does not exist) |
+| `slipbox_get_linked_notes` | Get notes linked to/from a note |
 
 ### Search & Discovery
 
 | Tool | Description |
 |------|-------------|
-| `zk_search_notes` | Search by text (BM25-ranked), tags, or type |
-| `zk_find_similar_notes` | Find notes similar to a given note |
-| `zk_find_central_notes` | Find most connected notes |
-| `zk_find_orphaned_notes` | Find unconnected notes |
-| `zk_list_notes_by_date` | List notes by date range |
-| `zk_get_all_tags` | List all tags |
+| `slipbox_search_notes` | Search by text (BM25-ranked), tags, or type |
+| `slipbox_find_similar_notes` | Find notes similar to a given note |
+| `slipbox_find_central_notes` | Find most connected notes |
+| `slipbox_find_orphaned_notes` | Find unconnected notes |
+| `slipbox_list_notes_by_date` | List notes by date range |
+| `slipbox_get_all_tags` | List all tags |
 
 ### Cluster Analysis
 
 | Tool | Description |
 |------|-------------|
-| `zk_get_cluster_report` | Get pending clusters needing structure notes |
-| `zk_create_structure_from_cluster` | Create structure note from cluster |
-| `zk_refresh_clusters` | Regenerate cluster analysis |
-| `zk_dismiss_cluster` | Permanently dismiss cluster from suggestions |
+| `slipbox_get_cluster_report` | Get pending clusters needing structure notes |
+| `slipbox_create_structure_from_cluster` | Create structure note from cluster |
+| `slipbox_refresh_clusters` | Regenerate cluster analysis |
+| `slipbox_dismiss_cluster` | Permanently dismiss cluster from suggestions |
 
 ### Maintenance
 
 | Tool | Description |
 |------|-------------|
-| `zk_rebuild_index` | Rebuild database index from files |
+| `slipbox_rebuild_index` | Rebuild database index from files |
 
 ---
 
@@ -335,18 +335,18 @@ Content here...
 - reference [[20250728T125429845760000]] Member of structure
 ```
 
-You can edit these files directly in any text editor or Obsidian. Run `zk_rebuild_index` after external edits.
+You can edit these files directly in any text editor or Obsidian. Run `slipbox_rebuild_index` after external edits.
 
 ---
 
 ## Upgrading
 
-After pulling new versions, restart Claude Desktop. If the release notes mention database changes, run `zk_rebuild_index` once to bring your existing database up to date.
+After pulling new versions, restart Claude Desktop. If the release notes mention database changes, run `slipbox_rebuild_index` once to bring your existing database up to date.
 
 **Upgrading to FTS5 search (any version after the FTS5 release):** The full-text search index is created automatically when the server starts against a new database. For existing databases, the FTS5 table will be created on first startup but will be empty until you run:
 
 ```
-zk_rebuild_index
+slipbox_rebuild_index
 ```
 
 This populates the BM25 index from your existing notes. Search results will not be relevance-ranked until this is done.
@@ -375,10 +375,10 @@ If your notes directory ends up at `./~/...` relative to CWD, you used `~` in th
 
 ### Search returns no results
 
-1. The FTS5 index may not be populated. Run `zk_rebuild_index` once to index existing notes.
-2. If you recently edited notes outside Claude, the index may be stale. Run `zk_rebuild_index`.
+1. The FTS5 index may not be populated. Run `slipbox_rebuild_index` once to index existing notes.
+2. If you recently edited notes outside Claude, the index may be stale. Run `slipbox_rebuild_index`.
 
-### `zk_list_notes_by_date` returns empty results
+### `slipbox_list_notes_by_date` returns empty results
 
 If `start_date` is later than `end_date`, no notes match and an empty result is returned — this is expected behavior, not an error.
 
@@ -387,7 +387,7 @@ If `start_date` is later than `end_date`, no notes match and an empty result is 
 If notes were edited outside the MCP server:
 
 ```
-zk_rebuild_index
+slipbox_rebuild_index
 ```
 
 ### Cluster detection not running
@@ -417,6 +417,32 @@ cat ~/.local/share/mcp/slipbox/watcher.log
 ./scripts/install-file-watcher.sh --uninstall
 ./scripts/install-file-watcher.sh
 ```
+
+### Upgrading from `ZETTELKASTEN_*` environment variables
+
+If you previously used `ZETTELKASTEN_NOTES_DIR`, `ZETTELKASTEN_DATABASE_PATH`, or other `ZETTELKASTEN_*` variables, they are **no longer read**. Rename them to their `SLIPBOX_*` equivalents:
+
+| Old | New |
+|-----|-----|
+| `ZETTELKASTEN_NOTES_DIR` | `SLIPBOX_NOTES_DIR` |
+| `ZETTELKASTEN_DATABASE_PATH` | `SLIPBOX_DATABASE_PATH` |
+| `ZETTELKASTEN_LOG_LEVEL` | `SLIPBOX_LOG_LEVEL` |
+| `ZETTELKASTEN_BASE_DIR` | `SLIPBOX_BASE_DIR` |
+| `ZETTELKASTEN_SERVER_NAME` | `SLIPBOX_SERVER_NAME` |
+
+The server logs a warning if old names are detected, but does not migrate them automatically.
+
+### Cluster report path is not configurable
+
+The cluster analysis report always writes to `~/.local/share/mcp/slipbox/cluster-analysis.json`, regardless of `SLIPBOX_BASE_DIR` or `SLIPBOX_NOTES_DIR`. If you use non-default paths, the cluster report will still be in the default location.
+
+### Install scripts are macOS-only
+
+The `scripts/install-cluster-detection.sh` and `scripts/install-file-watcher.sh` scripts use `launchctl` and `~/Library/LaunchAgents/`, which only exist on macOS. On Linux, you'll need to create equivalent systemd units or cron jobs manually. See the manual test commands in the relevant README sections to verify the underlying Python scripts work on your platform.
+
+### Default paths are relative to the working directory
+
+If `SLIPBOX_NOTES_DIR` and `SLIPBOX_DATABASE_PATH` are not set, the server defaults to `data/notes` and `data/db/slipbox.db` **relative to the current working directory**. When running via Claude Desktop, the CWD may not be what you expect. Always set absolute paths in `claude_desktop_config.json` to avoid this.
 
 ---
 
@@ -517,19 +543,19 @@ SLIPBOX_LOG_LEVEL=DEBUG python -c "from slipbox_mcp.main import main; main()"
 
 ## CLI Tool
 
-The `zk` command provides terminal access for mechanical operations:
+The `slipbox` command provides terminal access for mechanical operations:
 
 ```bash
-zk status          # Overview of notes, tags, orphans, pending clusters
-zk search <query>  # Find notes by text
-zk clusters        # Show pending structure note candidates
-zk orphans         # List unconnected notes
-zk rebuild         # Rebuild index (add --clusters to refresh cluster analysis)
-zk export <id>     # Export note markdown to stdout
-zk tags            # List all tags with usage counts
+slipbox status          # Overview of notes, tags, orphans, pending clusters
+slipbox search <query>  # Find notes by text
+slipbox clusters        # Show pending structure note candidates
+slipbox orphans         # List unconnected notes
+slipbox rebuild         # Rebuild index (add --clusters to refresh cluster analysis)
+slipbox export <id>     # Export note markdown to stdout
+slipbox tags            # List all tags with usage counts
 ```
 
-Install: `pipx install --editable .` (adds `zk` to your PATH)
+Install: `pipx install --editable .` (adds `slipbox` to your PATH)
 
 ---
 

--- a/demo.md
+++ b/demo.md
@@ -214,28 +214,28 @@ Data Architecture Knowledge Map
 When connected to Claude Desktop, the server exposes these tools:
 
 ```bash
-grep 'def zk_' src/slipbox_mcp/server/mcp_server.py | sed 's/.*def //' | sed 's/(.*//' | sed 's/^/  /'
+grep 'def slipbox_' src/slipbox_mcp/server/mcp_server.py | sed 's/.*def //' | sed 's/(.*//' | sed 's/^/  /'
 ```
 
 ```output
-  zk_create_note
-  zk_get_note
-  zk_update_note
-  zk_delete_note
-  zk_create_link
-  zk_remove_link
-  zk_search_notes
-  zk_get_linked_notes
-  zk_get_all_tags
-  zk_find_similar_notes
-  zk_find_central_notes
-  zk_find_orphaned_notes
-  zk_list_notes_by_date
-  zk_rebuild_index
-  zk_get_cluster_report
-  zk_create_structure_from_cluster
-  zk_refresh_clusters
-  zk_dismiss_cluster
+  slipbox_create_note
+  slipbox_get_note
+  slipbox_update_note
+  slipbox_delete_note
+  slipbox_create_link
+  slipbox_remove_link
+  slipbox_search_notes
+  slipbox_get_linked_notes
+  slipbox_get_all_tags
+  slipbox_find_similar_notes
+  slipbox_find_central_notes
+  slipbox_find_orphaned_notes
+  slipbox_list_notes_by_date
+  slipbox_rebuild_index
+  slipbox_get_cluster_report
+  slipbox_create_structure_from_cluster
+  slipbox_refresh_clusters
+  slipbox_dismiss_cluster
 ```
 
 Seven semantic link types connect notes: **reference**, **extends**, **refines**, **contradicts**, **questions**, **supports**, **related**. These typed relationships let Claude navigate the knowledge graph purposefully — not just by keyword.
@@ -284,7 +284,7 @@ Search for notes tagged "poetry" and "craft" about revision.
 Which notes are the most connected in my Zettelkasten? Show me the top 10.
 ```
 
-**What it shows:** `zk_find_central_notes` traverses the link graph and surfaces structural anchors. These are the notes everything else orbits. A knowledge base with no central notes is a pile of files; one with them is a network.
+**What it shows:** `slipbox_find_central_notes` traverses the link graph and surfaces structural anchors. These are the notes everything else orbits. A knowledge base with no central notes is a pile of files; one with them is a network.
 
 ---
 
@@ -393,7 +393,7 @@ This demonstrates that the user controls what gets captured. Claude proposes; th
 Find notes similar to [paste an ID from the central notes output].
 ```
 
-**What it shows:** `zk_find_similar_notes` computes similarity from shared tags, common links, and content overlap — three signals. Lower the threshold to 0.1 to show the spectrum of similarity scores.
+**What it shows:** `slipbox_find_similar_notes` computes similarity from shared tags, common links, and content overlap — three signals. Lower the threshold to 0.1 to show the spectrum of similarity scores.
 
 ---
 
@@ -406,7 +406,7 @@ Run a cluster analysis and show me the top clusters that need structure notes.
 
 Or to refresh stale data:
 ```
-Run zk_refresh_clusters and then show me the report.
+Run slipbox_refresh_clusters and then show me the report.
 ```
 
 **What it shows:** The cluster detector finds groups of co-occurring tags that lack an organizing structure note. Each cluster gets a score based on note count, orphan ratio, link density, and recency. Point out:
@@ -422,7 +422,7 @@ Run zk_refresh_clusters and then show me the report.
 Take the highest-scoring cluster and create a structure note for it. Link it to all the member notes.
 ```
 
-**What it shows:** `zk_create_structure_from_cluster` does the full scaffolding automatically: creates the structure note, writes a TODO synthesis stub, creates bidirectional `reference` links to every member note, and dismisses the cluster from future reports. This is the core value proposition: Claude turning emergent patterns into organized knowledge.
+**What it shows:** `slipbox_create_structure_from_cluster` does the full scaffolding automatically: creates the structure note, writes a TODO synthesis stub, creates bidirectional `reference` links to every member note, and dismisses the cluster from future reports. This is the core value proposition: Claude turning emergent patterns into organized knowledge.
 
 ---
 
@@ -438,7 +438,7 @@ Or a date range:
 List notes created between 2026-01-01 and 2026-03-01.
 ```
 
-**What it shows:** `zk_list_notes_by_date` with `use_updated=true` vs `false`. Useful for reviewing what was captured during a specific project or time period.
+**What it shows:** `slipbox_list_notes_by_date` with `use_updated=true` vs `false`. Useful for reviewing what was captured during a specific project or time period.
 
 ---
 
@@ -449,7 +449,7 @@ List notes created between 2026-01-01 and 2026-03-01.
 Show me all the tags in my Zettelkasten.
 ```
 
-**What it shows:** `zk_get_all_tags` returns the full vocabulary alphabetically. Point out that tag consistency is a hygiene problem in any knowledge base — this is how Claude can check before creating notes with new tags. Say to Claude:
+**What it shows:** `slipbox_get_all_tags` returns the full vocabulary alphabetically. Point out that tag consistency is a hygiene problem in any knowledge base — this is how Claude can check before creating notes with new tags. Say to Claude:
 
 ```
 Before creating any new notes, check the existing tags and tell me which ones are most relevant to software architecture.
@@ -600,7 +600,7 @@ Capture these 10 screenshots during a demo run. Each one tells a specific part o
 
 ### 8. Structure Note Creation (Section 11)
 
-**Capture:** `zk_create_structure_from_cluster` output: structure note created, N/N member notes linked, cluster dismissed.
+**Capture:** `slipbox_create_structure_from_cluster` output: structure note created, N/N member notes linked, cluster dismissed.
 
 **Why:** The payoff of cluster detection. One command turns an emergent pattern into organized knowledge. The "big demo moment."
 

--- a/docs/SYSTEM_PROMPT.md
+++ b/docs/SYSTEM_PROMPT.md
@@ -25,19 +25,19 @@ Keep it conversational and non-intrusive. Example:
 
 **User responses:**
 
-- **Yes/Address it**: Use `zk_create_structure_from_cluster` (auto-dismisses the cluster)
+- **Yes/Address it**: Use `slipbox_create_structure_from_cluster` (auto-dismisses the cluster)
 - **Skip for now**: Don't mention it again this session
-- **Dismiss permanently**: Use `zk_dismiss_cluster` to remove from future suggestions
+- **Dismiss permanently**: Use `slipbox_dismiss_cluster` to remove from future suggestions
 
-Cluster analysis refreshes automatically when stale (>24h). Use `zk_refresh_clusters` for immediate regeneration.
+Cluster analysis refreshes automatically when stale (>24h). Use `slipbox_refresh_clusters` for immediate regeneration.
 
 ### Automatic Knowledge Capture
 
 Auto-capture knowledge from conversations without asking permission. When the user shares insights, observations, theories, connections between ideas, or questions representing knowledge gaps:
 
-1. Search existing notes first (`zk_search_notes`) to avoid duplication
-2. Create atomic notes for distinct ideas (`zk_create_note`)
-3. Link to relevant existing knowledge (`zk_create_link`)
+1. Search existing notes first (`slipbox_search_notes`) to avoid duplication
+2. Create atomic notes for distinct ideas (`slipbox_create_note`)
+3. Link to relevant existing knowledge (`slipbox_create_link`)
 4. Tag appropriately (2-5 tags)
 5. Continue conversation normally
 
@@ -103,38 +103,38 @@ Create structure notes when 7-15 notes cluster around a concept without one. Str
 - Identify tensions and open questions
 - Link bidirectionally to all member notes
 
-Use `zk_get_cluster_report` to find clusters needing structure notes.
+Use `slipbox_get_cluster_report` to find clusters needing structure notes.
 
 ### Workflow Patterns
 
 **Processing new information:**
 
-1. Search for existing coverage (`zk_search_notes`)
-2. Create note if novel (`zk_create_note`)
-3. Link immediately (`zk_create_link`)
+1. Search for existing coverage (`slipbox_search_notes`)
+2. Create note if novel (`slipbox_create_note`)
+3. Link immediately (`slipbox_create_link`)
 
 **Exploring a topic:**
 
-1. Search for relevant notes (`zk_search_notes`)
-2. Find main hubs (`zk_find_central_notes`)
-3. Follow connections (`zk_get_linked_notes`)
-4. Find similar notes to surface unexpected connections (`zk_find_similar_notes`)
+1. Search for relevant notes (`slipbox_search_notes`)
+2. Find main hubs (`slipbox_find_central_notes`)
+3. Follow connections (`slipbox_get_linked_notes`)
+4. Find similar notes to surface unexpected connections (`slipbox_find_similar_notes`)
 
 **Batch processing** (larger volumes of content):
 
 1. Extract 5-10 distinct atomic ideas before creating any notes
-2. Search for existing coverage on each (`zk_search_notes`)
+2. Search for existing coverage on each (`slipbox_search_notes`)
 3. Create notes for novel ideas, skipping duplicates
 4. Link the batch to each other and to existing knowledge
 
 **Analyzing and improving a note:**
 
 1. Use the `analyze_note` prompt to evaluate atomicity, connectivity, and clarity
-2. Search for related notes based on the analysis (`zk_search_notes`)
+2. Search for related notes based on the analysis (`slipbox_search_notes`)
 3. Create links, update tags, or split the note based on recommendations
 
 **Maintenance:**
 
-1. Integrate isolated notes (`zk_find_orphaned_notes`)
-2. Find emergent clusters (`zk_get_cluster_report`)
-3. Formalize clusters into structure notes (`zk_create_structure_from_cluster`)
+1. Integrate isolated notes (`slipbox_find_orphaned_notes`)
+2. Find emergent clusters (`slipbox_get_cluster_report`)
+3. Formalize clusters into structure notes (`slipbox_create_structure_from_cluster`)

--- a/docs/plans/2026-04-03-missing-tests.md
+++ b/docs/plans/2026-04-03-missing-tests.md
@@ -503,7 +503,7 @@ git commit -m "test: add coverage for cluster_service pure functions"
 **Files:**
 - Modify: `tests/test_mcp_server.py`
 
-Add test classes for the uncovered tools: `zk_update_note`, `zk_delete_note`, `zk_remove_link`, `zk_get_linked_notes`, `zk_get_all_tags`, `zk_find_similar_notes` (happy path), `zk_find_central_notes` (happy path), `zk_find_orphaned_notes`, `zk_list_notes_by_date`, `zk_rebuild_index`, `_parse_refs`, and cluster tools.
+Add test classes for the uncovered tools: `slipbox_update_note`, `slipbox_delete_note`, `slipbox_remove_link`, `slipbox_get_linked_notes`, `slipbox_get_all_tags`, `slipbox_find_similar_notes` (happy path), `slipbox_find_central_notes` (happy path), `slipbox_find_orphaned_notes`, `slipbox_list_notes_by_date`, `slipbox_rebuild_index`, `_parse_refs`, and cluster tools.
 
 All follow MockServerBase pattern. Tests for each tool cover:
 1. Happy path output format

--- a/docs/reddit-launch-post.md
+++ b/docs/reddit-launch-post.md
@@ -21,7 +21,7 @@ So I built **slipbox-mcp** -- an MCP server that gives Claude direct access to a
 - BM25-ranked full-text search via SQLite FTS5
 - Automatic cluster detection -- finds groups of related notes that might need a structure note
 - Graph analysis: find central notes, orphans, similar notes
-- CLI tool (`zk`) for quick terminal access
+- CLI tool (`slipbox`) for quick terminal access
 
 **How it works in practice:**
 

--- a/docs/reddit-launch-post.md
+++ b/docs/reddit-launch-post.md
@@ -1,0 +1,58 @@
+# Reddit Launch Post Draft
+
+Target subreddits: r/zettelkasten, r/pkm, r/ObsidianMD, r/ClaudeAI
+
+---
+
+## Title
+
+I built an MCP server that turns Claude into a Zettelkasten partner
+
+## Body
+
+I've been building a Zettelkasten for [TIME PERIOD] and kept running into the same friction: capturing ideas during a conversation with Claude meant copy-pasting between apps, manually creating links, and hoping I'd remember to file things properly later.
+
+So I built **slipbox-mcp** -- an MCP server that gives Claude direct access to a Zettelkasten. It stores notes as plain Markdown files with YAML frontmatter, so they work with Obsidian, any text editor, or git.
+
+**What it does:**
+
+- Creates atomic notes (fleeting, literature, permanent, structure, hub) following Zettelkasten principles
+- Semantic links between notes (extends, refines, contradicts, supports, questions, reference, related)
+- BM25-ranked full-text search via SQLite FTS5
+- Automatic cluster detection -- finds groups of related notes that might need a structure note
+- Graph analysis: find central notes, orphans, similar notes
+- CLI tool (`zk`) for quick terminal access
+
+**How it works in practice:**
+
+You're having a conversation with Claude about [TOPIC]. An insight comes up. Instead of breaking flow, Claude searches your existing notes, creates a new permanent note, and links it to related ideas -- all within the conversation. At the start of each session, Claude can check for emerging clusters and suggest structure notes.
+
+**The key design decisions:**
+
+- Plain Markdown files -- no lock-in, works with Obsidian, vim, whatever
+- SQLite for indexing -- fast search without a separate service
+- Seven semantic link types -- not just "related", but *how* ideas connect
+- Structure notes emerge from clusters, not top-down categories
+
+**Tech details:**
+
+- Python 3.10+, runs as an MCP server for Claude Desktop or Claude Code
+- ~220 unit tests, tool contract tests, and LLM evals
+- Optional file watcher for auto-indexing when you edit in Obsidian
+- MIT licensed
+
+GitHub: [GITHUB_URL]
+
+I'd love feedback on the approach. Has anyone else tried integrating AI with their Zettelkasten workflow?
+
+---
+
+## Notes for posting
+
+- r/zettelkasten: Lead with the Zettelkasten methodology angle. Emphasize semantic links and structure note emergence.
+- r/pkm: Broader framing -- "AI-assisted knowledge management". Mention Obsidian compatibility.
+- r/ObsidianMD: Lead with "works with your existing Obsidian vault". Emphasize plain Markdown, file watcher.
+- r/ClaudeAI: Lead with MCP server angle. Emphasize the developer experience and tool descriptions.
+- Adjust tone per subreddit. r/zettelkasten is methodological; r/ClaudeAI is technical.
+- Post on a weekday morning (US time) for best visibility.
+- Reply to early comments quickly to boost engagement.

--- a/evals/tool_contracts/test_chaining.py
+++ b/evals/tool_contracts/test_chaining.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.contract
 class TestCreateThenSearch:
     def test_created_note_is_searchable(self, tool):
         """Create a note, then search for it by title -- should find it."""
-        create_result = tool("zk_create_note")(
+        create_result = tool("slipbox_create_note")(
             title="Unique Searchable Concept",
             content="A note about a very unique concept for search testing.",
             tags="search-test",
@@ -17,28 +17,28 @@ class TestCreateThenSearch:
         note_id = extract_note_id(create_result)
 
         # Rebuild index to ensure FTS5 picks it up
-        tool("zk_rebuild_index")()
+        tool("slipbox_rebuild_index")()
 
-        search_result = tool("zk_search_notes")(query="Unique Searchable Concept")
+        search_result = tool("slipbox_search_notes")(query="Unique Searchable Concept")
         assert note_id in search_result, "Created note should appear in search results"
 
 
 class TestCreateLinkThenGet:
     def test_linked_note_appears_in_get_linked(self, tool):
         """Create two notes, link them, then verify get_linked_notes shows the link."""
-        r1 = tool("zk_create_note")(title="Note Alpha", content="Alpha content")
-        r2 = tool("zk_create_note")(title="Note Beta", content="Beta content")
+        r1 = tool("slipbox_create_note")(title="Note Alpha", content="Alpha content")
+        r2 = tool("slipbox_create_note")(title="Note Beta", content="Beta content")
         id1 = extract_note_id(r1)
         id2 = extract_note_id(r2)
 
-        tool("zk_create_link")(
+        tool("slipbox_create_link")(
             source_id=id1,
             target_id=id2,
             link_type="extends",
             description="Alpha extends Beta",
         )
 
-        linked = tool("zk_get_linked_notes")(note_id=id1, direction="outgoing")
+        linked = tool("slipbox_get_linked_notes")(note_id=id1, direction="outgoing")
         assert "Note Beta" in linked
         assert "extends" in linked.lower()
 
@@ -46,36 +46,36 @@ class TestCreateLinkThenGet:
 class TestUpdateThenSearch:
     def test_update_then_search(self, tool):
         """Create note, update content, rebuild index, search for new content."""
-        create_result = tool("zk_create_note")(
+        create_result = tool("slipbox_create_note")(
             title="Mutable Concept",
             content="Original content about widgets.",
         )
         note_id = extract_note_id(create_result)
-        tool("zk_rebuild_index")()
+        tool("slipbox_rebuild_index")()
 
         # Update content
-        tool("zk_update_note")(note_id=note_id, content="Revised content about quantum entanglement.")
-        tool("zk_rebuild_index")()
+        tool("slipbox_update_note")(note_id=note_id, content="Revised content about quantum entanglement.")
+        tool("slipbox_rebuild_index")()
 
-        search_result = tool("zk_search_notes")(query="quantum entanglement")
+        search_result = tool("slipbox_search_notes")(query="quantum entanglement")
         assert note_id in search_result, "Updated note should appear in search for new content"
 
 
 class TestDeleteThenGet:
     def test_delete_then_get(self, tool):
         """Create note, delete it, verify get returns 'not found'."""
-        create_result = tool("zk_create_note")(
+        create_result = tool("slipbox_create_note")(
             title="Ephemeral Note", content="Soon to be gone."
         )
         note_id = extract_note_id(create_result)
 
         # Verify it exists
-        get_result = tool("zk_get_note")(identifier=note_id)
+        get_result = tool("slipbox_get_note")(identifier=note_id)
         assert "# Ephemeral Note" in get_result
 
         # Delete
-        tool("zk_delete_note")(note_id=note_id)
+        tool("slipbox_delete_note")(note_id=note_id)
 
         # Verify gone
-        get_after = tool("zk_get_note")(identifier=note_id)
+        get_after = tool("slipbox_get_note")(identifier=note_id)
         assert "not found" in get_after.lower()

--- a/evals/tool_contracts/test_output_format.py
+++ b/evals/tool_contracts/test_output_format.py
@@ -8,55 +8,55 @@ pytestmark = pytest.mark.contract
 
 class TestNoteToolOutputs:
     def test_create_note_returns_id(self, tool):
-        result = tool("zk_create_note")(title="Test Note", content="Test content")
+        result = tool("slipbox_create_note")(title="Test Note", content="Test content")
         assert "created successfully" in result.lower()
         assert "ID:" in result
 
     def test_get_note_returns_markdown_heading(self, tool):
-        create_result = tool("zk_create_note")(title="My Title", content="Body here")
+        create_result = tool("slipbox_create_note")(title="My Title", content="Body here")
         note_id = extract_note_id(create_result)
-        get_result = tool("zk_get_note")(identifier=note_id)
+        get_result = tool("slipbox_get_note")(identifier=note_id)
         assert "# My Title" in get_result
 
     def test_get_note_not_found(self, tool):
-        result = tool("zk_get_note")(identifier="nonexistent-id-12345")
+        result = tool("slipbox_get_note")(identifier="nonexistent-id-12345")
         assert "not found" in result.lower()
 
     def test_delete_note_confirms(self, tool):
-        create_result = tool("zk_create_note")(title="To Delete", content="Goodbye")
+        create_result = tool("slipbox_create_note")(title="To Delete", content="Goodbye")
         note_id = extract_note_id(create_result)
-        delete_result = tool("zk_delete_note")(note_id=note_id)
+        delete_result = tool("slipbox_delete_note")(note_id=note_id)
         assert "deleted" in delete_result.lower()
 
 
 class TestSearchToolOutputs:
     def test_search_with_results(self, tool):
-        tool("zk_create_note")(
+        tool("slipbox_create_note")(
             title="Epistemology Deep Dive",
             content="About epistemology and knowledge.",
             tags="philosophy,epistemology",
         )
-        tool("zk_rebuild_index")()
-        result = tool("zk_search_notes")(query="epistemology")
+        tool("slipbox_rebuild_index")()
+        result = tool("slipbox_search_notes")(query="epistemology")
         assert "found" in result.lower() or "result" in result.lower()
 
     def test_search_no_results(self, tool):
-        result = tool("zk_search_notes")(query="xyznonexistent")
+        result = tool("slipbox_search_notes")(query="xyznonexistent")
         assert "no" in result.lower() or "0" in result
 
     def test_find_orphaned_notes(self, tool):
-        tool("zk_create_note")(title="Lonely Note", content="No links", tags="orphan")
-        result = tool("zk_find_orphaned_notes")()
+        tool("slipbox_create_note")(title="Lonely Note", content="No links", tags="orphan")
+        result = tool("slipbox_find_orphaned_notes")()
         assert "Lonely Note" in result or "orphan" in result.lower()
 
 
 class TestLinkToolOutputs:
     def test_create_link_confirms(self, tool):
-        r1 = tool("zk_create_note")(title="Source", content="Source note")
-        r2 = tool("zk_create_note")(title="Target", content="Target note")
+        r1 = tool("slipbox_create_note")(title="Source", content="Source note")
+        r2 = tool("slipbox_create_note")(title="Target", content="Target note")
         id1 = extract_note_id(r1)
         id2 = extract_note_id(r2)
-        result = tool("zk_create_link")(
+        result = tool("slipbox_create_link")(
             source_id=id1,
             target_id=id2,
             link_type="supports",
@@ -65,62 +65,62 @@ class TestLinkToolOutputs:
         assert "created" in result.lower() or "link" in result.lower()
 
     def test_get_linked_notes(self, tool):
-        r1 = tool("zk_create_note")(title="Hub Note", content="Hub content")
-        r2 = tool("zk_create_note")(title="Spoke Note", content="Spoke content")
+        r1 = tool("slipbox_create_note")(title="Hub Note", content="Hub content")
+        r2 = tool("slipbox_create_note")(title="Spoke Note", content="Spoke content")
         id1 = extract_note_id(r1)
         id2 = extract_note_id(r2)
-        tool("zk_create_link")(
+        tool("slipbox_create_link")(
             source_id=id1,
             target_id=id2,
             link_type="reference",
             description="Test",
         )
-        result = tool("zk_get_linked_notes")(note_id=id1, direction="outgoing")
+        result = tool("slipbox_get_linked_notes")(note_id=id1, direction="outgoing")
         assert "Spoke Note" in result
 
 
 class TestUpdateToolOutputs:
     def test_update_note_title(self, tool):
         """Create a note, update its title, verify get returns the new title."""
-        create_result = tool("zk_create_note")(title="Old Title", content="Body text")
+        create_result = tool("slipbox_create_note")(title="Old Title", content="Body text")
         note_id = extract_note_id(create_result)
-        update_result = tool("zk_update_note")(note_id=note_id, title="New Title")
+        update_result = tool("slipbox_update_note")(note_id=note_id, title="New Title")
         assert "updated" in update_result.lower()
-        get_result = tool("zk_get_note")(identifier=note_id)
+        get_result = tool("slipbox_get_note")(identifier=note_id)
         assert "# New Title" in get_result
 
 
 class TestRemoveLinkOutputs:
     def test_remove_link(self, tool):
         """Create two notes + link, remove link, verify no links remain."""
-        r1 = tool("zk_create_note")(title="Left Note", content="Left content")
-        r2 = tool("zk_create_note")(title="Right Note", content="Right content")
+        r1 = tool("slipbox_create_note")(title="Left Note", content="Left content")
+        r2 = tool("slipbox_create_note")(title="Right Note", content="Right content")
         id1 = extract_note_id(r1)
         id2 = extract_note_id(r2)
-        tool("zk_create_link")(
+        tool("slipbox_create_link")(
             source_id=id1, target_id=id2, link_type="supports", description="Test"
         )
         # Verify link exists
-        linked = tool("zk_get_linked_notes")(note_id=id1, direction="outgoing")
+        linked = tool("slipbox_get_linked_notes")(note_id=id1, direction="outgoing")
         assert "Right Note" in linked
 
         # Remove and verify
-        remove_result = tool("zk_remove_link")(source_id=id1, target_id=id2)
+        remove_result = tool("slipbox_remove_link")(source_id=id1, target_id=id2)
         assert "removed" in remove_result.lower()
-        linked_after = tool("zk_get_linked_notes")(note_id=id1, direction="outgoing")
+        linked_after = tool("slipbox_get_linked_notes")(note_id=id1, direction="outgoing")
         assert "No" in linked_after or "Right Note" not in linked_after
 
 
 class TestTagToolOutputs:
     def test_get_all_tags(self, tool):
-        """Create notes with tags, call zk_get_all_tags, verify tags appear."""
-        tool("zk_create_note")(
+        """Create notes with tags, call slipbox_get_all_tags, verify tags appear."""
+        tool("slipbox_create_note")(
             title="Tagged Note A", content="Content A", tags="alpha,beta"
         )
-        tool("zk_create_note")(
+        tool("slipbox_create_note")(
             title="Tagged Note B", content="Content B", tags="gamma,beta"
         )
-        result = tool("zk_get_all_tags")()
+        result = tool("slipbox_get_all_tags")()
         assert "alpha" in result
         assert "beta" in result
         assert "gamma" in result
@@ -129,41 +129,41 @@ class TestTagToolOutputs:
 class TestSimilarNotesOutputs:
     def test_find_similar_notes(self, tool):
         """Create two notes with overlapping tags, verify find_similar returns the other."""
-        r1 = tool("zk_create_note")(
+        r1 = tool("slipbox_create_note")(
             title="Note About Dogs", content="Dogs are great pets", tags="animals,pets"
         )
-        tool("zk_create_note")(
+        tool("slipbox_create_note")(
             title="Note About Cats", content="Cats are also great pets", tags="animals,pets"
         )
         id1 = extract_note_id(r1)
-        result = tool("zk_find_similar_notes")(note_id=id1, threshold=0.1)
+        result = tool("slipbox_find_similar_notes")(note_id=id1, threshold=0.1)
         assert "Cats" in result
 
 
 class TestCentralNotesOutputs:
     def test_find_central_notes(self, tool):
         """Create a hub with 3+ links, verify find_central returns the hub."""
-        hub = tool("zk_create_note")(title="Central Hub", content="Hub content")
+        hub = tool("slipbox_create_note")(title="Central Hub", content="Hub content")
         hub_id = extract_note_id(hub)
         spoke_ids = []
         for i in range(3):
-            r = tool("zk_create_note")(
+            r = tool("slipbox_create_note")(
                 title=f"Spoke {i}", content=f"Spoke content {i}"
             )
             spoke_ids.append(extract_note_id(r))
         for sid in spoke_ids:
-            tool("zk_create_link")(
+            tool("slipbox_create_link")(
                 source_id=hub_id, target_id=sid, link_type="reference"
             )
-        result = tool("zk_find_central_notes")(limit=5)
+        result = tool("slipbox_find_central_notes")(limit=5)
         assert "Central Hub" in result
 
 
 class TestDateToolOutputs:
     def test_list_notes_by_date(self, tool):
         """Create notes, call list_notes_by_date, verify output contains notes."""
-        tool("zk_create_note")(title="Date Test Note", content="Some content")
-        result = tool("zk_list_notes_by_date")(limit=10)
+        tool("slipbox_create_note")(title="Date Test Note", content="Some content")
+        result = tool("slipbox_list_notes_by_date")(limit=10)
         assert "Date Test Note" in result
         assert "showing" in result.lower() or "result" in result.lower()
 
@@ -171,15 +171,15 @@ class TestDateToolOutputs:
 class TestRebuildIndexOutputs:
     def test_rebuild_index_reports_count(self, tool):
         """Create a note, rebuild index, verify output mentions note count."""
-        tool("zk_create_note")(title="Index Test", content="Rebuild me")
-        result = tool("zk_rebuild_index")()
+        tool("slipbox_create_note")(title="Index Test", content="Rebuild me")
+        result = tool("slipbox_rebuild_index")()
         assert "rebuilt" in result.lower()
         assert "Notes processed:" in result
 
 
 class TestErrorFormats:
     def test_invalid_note_type_lists_valid(self, tool):
-        result = tool("zk_create_note")(
+        result = tool("slipbox_create_note")(
             title="Bad", content="Bad", note_type="invalid"
         )
         assert "Invalid note type" in result
@@ -187,11 +187,11 @@ class TestErrorFormats:
         assert "permanent" in result
 
     def test_invalid_link_type_lists_valid(self, tool):
-        r1 = tool("zk_create_note")(title="A", content="A content")
-        r2 = tool("zk_create_note")(title="B", content="B content")
+        r1 = tool("slipbox_create_note")(title="A", content="A content")
+        r2 = tool("slipbox_create_note")(title="B", content="B content")
         id1 = extract_note_id(r1)
         id2 = extract_note_id(r2)
-        result = tool("zk_create_link")(
+        result = tool("slipbox_create_link")(
             source_id=id1, target_id=id2, link_type="invalid_type"
         )
         assert "Invalid link type" in result or "invalid" in result.lower()

--- a/src/slipbox_mcp/server/descriptions.py
+++ b/src/slipbox_mcp/server/descriptions.py
@@ -9,11 +9,11 @@ Prompt constants are prefixed with PROMPT_.
 # Note tools
 # ---------------------------------------------------------------------------
 
-ZK_CREATE_NOTE = """\
+SLIPBOX_CREATE_NOTE = """\
 Create a new atomic Zettelkasten note.
 
 Each note should contain exactly one idea. After creating, immediately
-link to related notes using zk_create_link.
+link to related notes using slipbox_create_link.
 
 Note Types:
 - fleeting: Quick captures, unprocessed thoughts (process within 24-48 hours)
@@ -26,7 +26,7 @@ Best Practices:
 - Title should express the idea in brief (understandable without reading content)
 - Content should be 3-7 paragraphs, enough to stand alone
 - Use 2-5 specific tags; prefer existing tags when they fit
-- Search first (zk_search_notes) to avoid duplicating existing notes
+- Search first (slipbox_search_notes) to avoid duplicating existing notes
 
 Args:
     title: Concise title expressing the core idea
@@ -36,7 +36,7 @@ Args:
     references: Newline-separated citations to external sources (e.g. "Ahrens, S. (2017). How to Take Smart Notes.\\nhttps://zettelkasten.de")\
 """
 
-ZK_GET_NOTE = """\
+SLIPBOX_GET_NOTE = """\
 Retrieve a note by ID or title.
 
 Returns full note content including metadata, tags, and links.
@@ -46,7 +46,7 @@ Args:
     identifier: Either the note ID (e.g. "20251217T172432480464000") or exact title\
 """
 
-ZK_UPDATE_NOTE = """\
+SLIPBOX_UPDATE_NOTE = """\
 Update an existing note.
 
 Only provided fields are updated; omitted fields remain unchanged.
@@ -62,7 +62,7 @@ Args:
     references: New newline-separated citations, or empty string to clear (optional)\
 """
 
-ZK_DELETE_NOTE = """\
+SLIPBOX_DELETE_NOTE = """\
 Delete a note permanently.
 
 Warning: This also removes all links to and from this note.
@@ -76,7 +76,7 @@ Args:
 # Link tools
 # ---------------------------------------------------------------------------
 
-ZK_CREATE_LINK = """\
+SLIPBOX_CREATE_LINK = """\
 Create a semantic link between two notes.
 
 Links are directional: source -> target. Use bidirectional=true for
@@ -104,7 +104,7 @@ Args:
     bidirectional: If true, creates inverse link from target to source\
 """
 
-ZK_REMOVE_LINK = """\
+SLIPBOX_REMOVE_LINK = """\
 Remove a link between two notes.
 
 Args:
@@ -113,7 +113,7 @@ Args:
     bidirectional: If true, removes links in both directions\
 """
 
-ZK_GET_LINKED_NOTES = """\
+SLIPBOX_GET_LINKED_NOTES = """\
 Get notes linked to or from a specific note.
 
 Use this to explore the knowledge graph around a note.
@@ -128,7 +128,7 @@ Args:
     direction: One of outgoing/incoming/both (default: both)\
 """
 
-ZK_GET_ALL_TAGS = """\
+SLIPBOX_GET_ALL_TAGS = """\
 Get all tags in the Zettelkasten.
 
 Returns alphabetically sorted list of all tags.
@@ -140,7 +140,7 @@ to maintain tag consistency across your knowledge base.\
 # Search tools
 # ---------------------------------------------------------------------------
 
-ZK_SEARCH_NOTES = """\
+SLIPBOX_SEARCH_NOTES = """\
 Search for notes by text, tags, or type.
 
 Searches across titles and content. Combine parameters for precise filtering.
@@ -158,7 +158,7 @@ Args:
     limit: Maximum results to return (default: 10)\
 """
 
-ZK_FIND_SIMILAR_NOTES = """\
+SLIPBOX_FIND_SIMILAR_NOTES = """\
 Find notes similar to a given note.
 
 Similarity is based on shared tags, common links, and content overlap.
@@ -170,7 +170,7 @@ Args:
     limit: Maximum results (default: 5)\
 """
 
-ZK_FIND_CENTRAL_NOTES = """\
+SLIPBOX_FIND_CENTRAL_NOTES = """\
 Find the most connected notes in the Zettelkasten.
 
 Central notes have the most incoming and outgoing links, making them
@@ -180,14 +180,14 @@ Args:
     limit: Maximum results (default: 10)\
 """
 
-ZK_FIND_ORPHANED_NOTES = """\
+SLIPBOX_FIND_ORPHANED_NOTES = """\
 Find notes with no connections to other notes.
 
 Orphaned notes represent unintegrated knowledge. Review these periodically
 to either link them to existing notes or identify candidates for deletion.\
 """
 
-ZK_LIST_NOTES_BY_DATE = """\
+SLIPBOX_LIST_NOTES_BY_DATE = """\
 List notes by creation or update date.
 
 Useful for reviewing recent work or finding notes from a specific period.
@@ -199,7 +199,7 @@ Args:
     limit: Maximum results (default: 10)\
 """
 
-ZK_REBUILD_INDEX = """\
+SLIPBOX_REBUILD_INDEX = """\
 Rebuild the database index from markdown files.
 
 Use this if notes were edited outside the MCP server or if the
@@ -210,7 +210,7 @@ database seems out of sync with the filesystem.\
 # Cluster tools
 # ---------------------------------------------------------------------------
 
-ZK_GET_CLUSTER_REPORT = """\
+SLIPBOX_GET_CLUSTER_REPORT = """\
 Get pending cluster analysis for structure note creation.
 
 Clusters are groups of notes sharing tags but lacking a structure note.
@@ -232,13 +232,13 @@ Args:
     refresh: Force regeneration of cluster analysis (default: false)\
 """
 
-ZK_CREATE_STRUCTURE_FROM_CLUSTER = """\
+SLIPBOX_CREATE_STRUCTURE_FROM_CLUSTER = """\
 Create a structure note from a detected cluster.
 
 Generates a structure note organizing all notes in the cluster,
 with bidirectional links to each member note.
 
-Run zk_get_cluster_report first to see available clusters and their IDs.
+Run slipbox_get_cluster_report first to see available clusters and their IDs.
 
 Args:
     cluster_id: ID from cluster report (e.g. "jackson-mac-low-chance-operations")
@@ -246,7 +246,7 @@ Args:
     create_links: Create bidirectional links to member notes (default: true)\
 """
 
-ZK_REFRESH_CLUSTERS = """\
+SLIPBOX_REFRESH_CLUSTERS = """\
 Regenerate cluster analysis and save report.
 
 Analyzes all notes for emergent clusters based on:
@@ -257,7 +257,7 @@ Analyzes all notes for emergent clusters based on:
 Results saved to ~/.local/share/mcp/slipbox/cluster-analysis.json\
 """
 
-ZK_DISMISS_CLUSTER = """\
+SLIPBOX_DISMISS_CLUSTER = """\
 Permanently dismiss a cluster from maintenance suggestions.
 
 Use this when a cluster has been reviewed and determined not to need
@@ -398,9 +398,9 @@ Does the note contain exactly one idea? If multiple concepts are present:
 
 **Do this before suggesting connections:**
 1. Extract 2-3 key terms from the note
-2. Run `zk_search_notes` for each term to find related existing notes
-3. Run `zk_find_similar_notes` if this is an existing note ID
-4. Check `zk_find_central_notes` to see if this relates to a knowledge hub
+2. Run `slipbox_search_notes` for each term to find related existing notes
+3. Run `slipbox_find_similar_notes` if this is an existing note ID
+4. Check `slipbox_find_central_notes` to see if this relates to a knowledge hub
 
 **Then report:**
 - Specific existing notes this should link to (with IDs and titles)
@@ -424,7 +424,7 @@ Provide the rewritten version in a code block for easy copying.
 
 ## 4. Metadata Suggestions
 
-**Tags:** Run `zk_get_all_tags` first. Suggest 3-5 tags, preferring existing tags over new ones. If proposing a new tag, justify why existing tags don't fit.
+**Tags:** Run `slipbox_get_all_tags` first. Suggest 3-5 tags, preferring existing tags over new ones. If proposing a new tag, justify why existing tags don't fit.
 
 **Title:** Propose a clear, searchable title that expresses the core idea.
 
@@ -466,7 +466,7 @@ Based on what you found in the slipbox:
 [type with rationale]
 
 ### Rewritten Note
-[clean version ready for zk_create_note]
+[clean version ready for slipbox_create_note]
 
 ### Emergent Insights
 [questions, gaps, unexpected connections]

--- a/src/slipbox_mcp/server/tools/cluster_tools.py
+++ b/src/slipbox_mcp/server/tools/cluster_tools.py
@@ -5,10 +5,10 @@ from typing import Optional
 from slipbox_mcp.formatting import format_cluster_summary
 from slipbox_mcp.models.schema import LinkType, NoteType
 from slipbox_mcp.server.descriptions import (
-    ZK_CREATE_STRUCTURE_FROM_CLUSTER,
-    ZK_DISMISS_CLUSTER,
-    ZK_GET_CLUSTER_REPORT,
-    ZK_REFRESH_CLUSTERS,
+    SLIPBOX_CREATE_STRUCTURE_FROM_CLUSTER,
+    SLIPBOX_DISMISS_CLUSTER,
+    SLIPBOX_GET_CLUSTER_REPORT,
+    SLIPBOX_REFRESH_CLUSTERS,
 )
 
 logger = logging.getLogger(__name__)
@@ -21,8 +21,8 @@ def register_cluster_tools(server) -> None:
     zettel_service = server.zettel_service
     format_error = server.format_error_response
 
-    @mcp.tool(name="zk_get_cluster_report", description=ZK_GET_CLUSTER_REPORT)
-    def zk_get_cluster_report(
+    @mcp.tool(name="slipbox_get_cluster_report", description=SLIPBOX_GET_CLUSTER_REPORT)
+    def slipbox_get_cluster_report(
         min_score: float = 0.5,
         limit: int = 5,
         include_notes: bool = False,
@@ -30,10 +30,10 @@ def register_cluster_tools(server) -> None:
     ) -> str:
         try:
             if not 0.0 <= min_score <= 1.0:
-                logger.warning("zk_get_cluster_report: min_score %r out of range [0.0, 1.0]", min_score)
+                logger.warning("slipbox_get_cluster_report: min_score %r out of range [0.0, 1.0]", min_score)
                 return "Error: min_score must be between 0.0 and 1.0."
             if limit <= 0:
-                logger.warning("zk_get_cluster_report: limit %r must be a positive integer", limit)
+                logger.warning("slipbox_get_cluster_report: limit %r must be a positive integer", limit)
                 return "Error: limit must be a positive integer."
             if refresh:
                 report = cluster_service.detect_clusters()
@@ -60,8 +60,8 @@ def register_cluster_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_create_structure_from_cluster", description=ZK_CREATE_STRUCTURE_FROM_CLUSTER)
-    def zk_create_structure_from_cluster(
+    @mcp.tool(name="slipbox_create_structure_from_cluster", description=SLIPBOX_CREATE_STRUCTURE_FROM_CLUSTER)
+    def slipbox_create_structure_from_cluster(
         cluster_id: str,
         title: Optional[str] = None,
         create_links: bool = True
@@ -69,7 +69,7 @@ def register_cluster_tools(server) -> None:
         try:
             report = cluster_service.load_report()
             if not report:
-                return "No cluster report found. Run zk_get_cluster_report(refresh=True) first."
+                return "No cluster report found. Run slipbox_get_cluster_report(refresh=True) first."
 
             cluster = next((c for c in report.clusters if c.id == cluster_id), None)
             if not cluster:
@@ -114,8 +114,8 @@ def register_cluster_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_refresh_clusters", description=ZK_REFRESH_CLUSTERS)
-    def zk_refresh_clusters() -> str:
+    @mcp.tool(name="slipbox_refresh_clusters", description=SLIPBOX_REFRESH_CLUSTERS)
+    def slipbox_refresh_clusters() -> str:
         try:
             report = cluster_service.detect_clusters()
             path = cluster_service.save_report(report)
@@ -137,12 +137,12 @@ def register_cluster_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_dismiss_cluster", description=ZK_DISMISS_CLUSTER)
-    def zk_dismiss_cluster(cluster_id: str) -> str:
+    @mcp.tool(name="slipbox_dismiss_cluster", description=SLIPBOX_DISMISS_CLUSTER)
+    def slipbox_dismiss_cluster(cluster_id: str) -> str:
         try:
             report = cluster_service.load_report()
             if not report:
-                return "No cluster report found. Run zk_refresh_clusters first."
+                return "No cluster report found. Run slipbox_refresh_clusters first."
 
             if cluster_id not in [c.id for c in report.clusters]:
                 available = ', '.join(c.id for c in report.clusters[:5])

--- a/src/slipbox_mcp/server/tools/link_tools.py
+++ b/src/slipbox_mcp/server/tools/link_tools.py
@@ -16,8 +16,8 @@ def register_link_tools(server) -> None:
     zettel_service = server.zettel_service
     format_error = server.format_error_response
 
-    @mcp.tool(name="zk_create_link")
-    def zk_create_link(
+    @mcp.tool(name="slipbox_create_link")
+    def slipbox_create_link(
         source_id: str,
         target_id: str,
         link_type: str = "reference",
@@ -72,8 +72,8 @@ def register_link_tools(server) -> None:
                 return "A link of this type already exists between these notes. Try a different link type."
             return format_error(e)
 
-    @mcp.tool(name="zk_remove_link")
-    def zk_remove_link(
+    @mcp.tool(name="slipbox_remove_link")
+    def slipbox_remove_link(
         source_id: str,
         target_id: str,
         bidirectional: bool = False
@@ -98,14 +98,14 @@ def register_link_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_delete_link")
-    def zk_delete_link(
+    @mcp.tool(name="slipbox_delete_link")
+    def slipbox_delete_link(
         source_id: str,
         target_id: str,
     ) -> str:
         """Delete a specific link from one note to another.
 
-        Unlike zk_remove_link, this tool returns an error if no link exists
+        Unlike slipbox_remove_link, this tool returns an error if no link exists
         between the two notes.
 
         Args:
@@ -135,8 +135,8 @@ def register_link_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_get_linked_notes")
-    def zk_get_linked_notes(
+    @mcp.tool(name="slipbox_get_linked_notes")
+    def slipbox_get_linked_notes(
         note_id: str,
         direction: str = "both"
     ) -> str:
@@ -185,8 +185,8 @@ def register_link_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_get_all_tags")
-    def zk_get_all_tags() -> str:
+    @mcp.tool(name="slipbox_get_all_tags")
+    def slipbox_get_all_tags() -> str:
         """Get all tags in the Zettelkasten.
 
         Returns alphabetically sorted list of all tags.

--- a/src/slipbox_mcp/server/tools/note_tools.py
+++ b/src/slipbox_mcp/server/tools/note_tools.py
@@ -14,8 +14,8 @@ def register_note_tools(server) -> None:
     zettel_service = server.zettel_service
     format_error = server.format_error_response
 
-    @mcp.tool(name="zk_create_note")
-    def zk_create_note(
+    @mcp.tool(name="slipbox_create_note")
+    def slipbox_create_note(
         title: str,
         content: str,
         note_type: str = "permanent",
@@ -25,7 +25,7 @@ def register_note_tools(server) -> None:
         """Create a new atomic Zettelkasten note.
 
         Each note should contain exactly one idea. After creating, immediately
-        link to related notes using zk_create_link.
+        link to related notes using slipbox_create_link.
 
         Note Types:
         - fleeting: Quick captures, unprocessed thoughts (process within 24-48 hours)
@@ -38,7 +38,7 @@ def register_note_tools(server) -> None:
         - Title should express the idea in brief (understandable without reading content)
         - Content should be 3-7 paragraphs, enough to stand alone
         - Use 2-5 specific tags; prefer existing tags when they fit
-        - Search first (zk_search_notes) to avoid duplicating existing notes
+        - Search first (slipbox_search_notes) to avoid duplicating existing notes
 
         Args:
             title: Concise title expressing the core idea
@@ -67,8 +67,8 @@ def register_note_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_get_note")
-    def zk_get_note(identifier: str) -> str:
+    @mcp.tool(name="slipbox_get_note")
+    def slipbox_get_note(identifier: str) -> str:
         """Retrieve a note by ID or title.
 
         Returns full note content including metadata, tags, and links.
@@ -101,8 +101,8 @@ def register_note_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_update_note")
-    def zk_update_note(
+    @mcp.tool(name="slipbox_update_note")
+    def slipbox_update_note(
         note_id: str,
         title: Optional[str] = None,
         content: Optional[str] = None,
@@ -154,8 +154,8 @@ def register_note_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_delete_note")
-    def zk_delete_note(note_id: str) -> str:
+    @mcp.tool(name="slipbox_delete_note")
+    def slipbox_delete_note(note_id: str) -> str:
         """Delete a note permanently.
 
         Warning: This also removes all links to and from this note.

--- a/src/slipbox_mcp/server/tools/search_tools.py
+++ b/src/slipbox_mcp/server/tools/search_tools.py
@@ -16,8 +16,8 @@ def register_search_tools(server) -> None:
     zettel_service = server.zettel_service
     format_error = server.format_error_response
 
-    @mcp.tool(name="zk_search_notes")
-    def zk_search_notes(
+    @mcp.tool(name="slipbox_search_notes")
+    def slipbox_search_notes(
         query: Optional[str] = None,
         tags: Optional[str] = None,
         note_type: Optional[str] = None,
@@ -71,8 +71,8 @@ def register_search_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_find_similar_notes")
-    def zk_find_similar_notes(
+    @mcp.tool(name="slipbox_find_similar_notes")
+    def slipbox_find_similar_notes(
         note_id: str,
         threshold: float = 0.3,
         limit: int = 5
@@ -89,10 +89,10 @@ def register_search_tools(server) -> None:
         """
         try:
             if not 0.0 <= threshold <= 1.0:
-                logger.warning("zk_find_similar_notes: threshold %r out of range [0.0, 1.0]", threshold)
+                logger.warning("slipbox_find_similar_notes: threshold %r out of range [0.0, 1.0]", threshold)
                 return "Error: threshold must be between 0.0 and 1.0."
             if limit <= 0:
-                logger.warning("zk_find_similar_notes: limit %r must be a positive integer", limit)
+                logger.warning("slipbox_find_similar_notes: limit %r must be a positive integer", limit)
                 return "Error: limit must be a positive integer."
             similar_notes = zettel_service.find_similar_notes(str(note_id), threshold)
             similar_notes = similar_notes[:limit]
@@ -110,8 +110,8 @@ def register_search_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_find_central_notes")
-    def zk_find_central_notes(limit: int = 10) -> str:
+    @mcp.tool(name="slipbox_find_central_notes")
+    def slipbox_find_central_notes(limit: int = 10) -> str:
         """Find the most connected notes in the Zettelkasten.
 
         Central notes have the most incoming and outgoing links, making them
@@ -122,7 +122,7 @@ def register_search_tools(server) -> None:
         """
         try:
             if limit <= 0:
-                logger.warning("zk_find_central_notes: limit %r must be a positive integer", limit)
+                logger.warning("slipbox_find_central_notes: limit %r must be a positive integer", limit)
                 return "Error: limit must be a positive integer."
             central_notes = search_service.find_central_notes(limit)
             if not central_notes:
@@ -139,8 +139,8 @@ def register_search_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_find_orphaned_notes")
-    def zk_find_orphaned_notes() -> str:
+    @mcp.tool(name="slipbox_find_orphaned_notes")
+    def slipbox_find_orphaned_notes() -> str:
         """Find notes with no connections to other notes.
 
         Orphaned notes represent unintegrated knowledge. Review these periodically
@@ -161,8 +161,8 @@ def register_search_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_list_notes_by_date")
-    def zk_list_notes_by_date(
+    @mcp.tool(name="slipbox_list_notes_by_date")
+    def slipbox_list_notes_by_date(
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
         use_updated: bool = False,
@@ -228,8 +228,8 @@ def register_search_tools(server) -> None:
         except Exception as e:
             return format_error(e)
 
-    @mcp.tool(name="zk_rebuild_index")
-    def zk_rebuild_index() -> str:
+    @mcp.tool(name="slipbox_rebuild_index")
+    def slipbox_rebuild_index() -> str:
         """Rebuild the database index from markdown files.
 
         Use this if notes were edited outside the MCP server or if the

--- a/src/slipbox_mcp/services/search_service.py
+++ b/src/slipbox_mcp/services/search_service.py
@@ -52,7 +52,7 @@ class SearchService:
                 err = str(e).lower()
                 if "no such table" in err:
                     if "notes_fts" in err:
-                        logger.error("FTS5 table 'notes_fts' missing -- run zk_rebuild_index: %s", e)
+                        logger.error("FTS5 table 'notes_fts' missing -- run slipbox_rebuild_index: %s", e)
                     else:
                         logger.error("Required table missing from database schema: %s", e)
                     raise

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -70,11 +70,11 @@ class TestServerInitialization(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_create_note
+# Tool: slipbox_create_note
 # ---------------------------------------------------------------------------
 
 class TestCreateNoteTool(MockServerBase):
-    """zk_create_note — happy path and tag parsing."""
+    """slipbox_create_note — happy path and tag parsing."""
 
     NOTE_ID = "test123"
 
@@ -86,7 +86,7 @@ class TestCreateNoteTool(MockServerBase):
 
     def test_create_note_returns_success_message_with_id(self):
         # Arrange / Act
-        result = self._tool("zk_create_note")(
+        result = self._tool("slipbox_create_note")(
             title="Test Note",
             content="Test content",
             note_type="permanent",
@@ -100,7 +100,7 @@ class TestCreateNoteTool(MockServerBase):
     def test_create_note_passes_parsed_tags_and_type_to_service(self):
         """Comma-separated tag string is split and NoteType enum is resolved."""
         # Act
-        self._tool("zk_create_note")(
+        self._tool("slipbox_create_note")(
             title="Test Note",
             content="Test content",
             note_type="permanent",
@@ -119,7 +119,7 @@ class TestCreateNoteTool(MockServerBase):
     def test_create_note_invalid_type_returns_error_listing_valid_types(self):
         """An unrecognised note_type string is rejected before calling the service."""
         # Act
-        result = self._tool("zk_create_note")(
+        result = self._tool("slipbox_create_note")(
             title="Test", content="Body", note_type="bogus"
         )
 
@@ -130,11 +130,11 @@ class TestCreateNoteTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_get_note
+# Tool: slipbox_get_note
 # ---------------------------------------------------------------------------
 
 class TestGetNoteTool(MockServerBase):
-    """zk_get_note — retrieves and formats a note."""
+    """slipbox_get_note — retrieves and formats a note."""
 
     NOTE_ID = "test123"
     NOTE_TITLE = "Test Note"
@@ -157,7 +157,7 @@ class TestGetNoteTool(MockServerBase):
 
     def test_get_note_output_contains_title_id_and_content(self):
         # Act
-        result = self._tool("zk_get_note")(identifier=self.NOTE_ID)
+        result = self._tool("slipbox_get_note")(identifier=self.NOTE_ID)
 
         # Assert
         assert f"# {self.NOTE_TITLE}" in result, "Output should include markdown title heading"
@@ -165,16 +165,16 @@ class TestGetNoteTool(MockServerBase):
         assert self.NOTE_CONTENT in result, "Output should include note body content"
 
     def test_get_note_calls_service_with_identifier(self):
-        self._tool("zk_get_note")(identifier=self.NOTE_ID)
+        self._tool("slipbox_get_note")(identifier=self.NOTE_ID)
         self.mock_zettel_service.get_note.assert_called_with(self.NOTE_ID)
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_create_link
+# Tool: slipbox_create_link
 # ---------------------------------------------------------------------------
 
 class TestCreateLinkTool(MockServerBase):
-    """zk_create_link — creates and confirms bidirectional links."""
+    """slipbox_create_link — creates and confirms bidirectional links."""
 
     SOURCE_ID = "source123"
     TARGET_ID = "target456"
@@ -187,7 +187,7 @@ class TestCreateLinkTool(MockServerBase):
 
     def test_bidirectional_link_result_mentions_both_ids(self):
         # Act
-        result = self._tool("zk_create_link")(
+        result = self._tool("slipbox_create_link")(
             source_id=self.SOURCE_ID,
             target_id=self.TARGET_ID,
             link_type="extends",
@@ -201,7 +201,7 @@ class TestCreateLinkTool(MockServerBase):
         assert self.TARGET_ID in result, f"Expected target ID {self.TARGET_ID!r} in result, got {result!r}"
 
     def test_create_link_passes_correct_enum_to_service(self):
-        self._tool("zk_create_link")(
+        self._tool("slipbox_create_link")(
             source_id=self.SOURCE_ID,
             target_id=self.TARGET_ID,
             link_type="extends",
@@ -225,7 +225,7 @@ class TestCreateLinkTool(MockServerBase):
         )
 
         # Act
-        result = self._tool("zk_create_link")(
+        result = self._tool("slipbox_create_link")(
             source_id=self.SOURCE_ID,
             target_id=self.TARGET_ID,
             link_type="extends",
@@ -237,7 +237,7 @@ class TestCreateLinkTool(MockServerBase):
     def test_invalid_link_type_returns_error(self):
         """An unrecognised link_type string is rejected."""
         # Act
-        result = self._tool("zk_create_link")(
+        result = self._tool("slipbox_create_link")(
             source_id=self.SOURCE_ID,
             target_id=self.TARGET_ID,
             link_type="bogus",
@@ -248,11 +248,11 @@ class TestCreateLinkTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_search_notes
+# Tool: slipbox_search_notes
 # ---------------------------------------------------------------------------
 
 class TestSearchNotesTool(MockServerBase):
-    """zk_search_notes — returns formatted results from search_combined."""
+    """slipbox_search_notes — returns formatted results from search_combined."""
 
     def setup_method(self):
         super().setup_method()
@@ -277,7 +277,7 @@ class TestSearchNotesTool(MockServerBase):
 
     def test_search_result_count_and_note_titles_in_output(self):
         # Act
-        result = self._tool("zk_search_notes")(
+        result = self._tool("slipbox_search_notes")(
             query="test query",
             tags="tag1, tag2",
             note_type="permanent",
@@ -290,7 +290,7 @@ class TestSearchNotesTool(MockServerBase):
         assert "Note 2" in result, f"Expected 'Note 2' in result, got {result!r}"
 
     def test_search_notes_calls_service_with_parsed_args(self):
-        self._tool("zk_search_notes")(
+        self._tool("slipbox_search_notes")(
             query="test query",
             tags="tag1, tag2",
             note_type="permanent",
@@ -405,62 +405,62 @@ def test_service_update_with_empty_list_clears_references(zettel_service):
 class TestGuardClauses(MockServerBase):
     """MCP tools reject invalid numeric parameters before calling services."""
 
-    # Threshold bounds for zk_find_similar_notes
+    # Threshold bounds for slipbox_find_similar_notes
     VALID_THRESHOLD = 0.5
     THRESHOLD_ERROR = "Error: threshold must be between 0.0 and 1.0."
     LIMIT_ERROR = "Error: limit must be a positive integer."
     MIN_SCORE_ERROR = "Error: min_score must be between 0.0 and 1.0."
 
     def test_find_similar_notes_rejects_threshold_above_one(self):
-        result = self._tool("zk_find_similar_notes")(note_id="abc", threshold=1.5)
+        result = self._tool("slipbox_find_similar_notes")(note_id="abc", threshold=1.5)
         assert result == self.THRESHOLD_ERROR, f"Expected {self.THRESHOLD_ERROR!r}, got {result!r}"
         self.mock_zettel_service.find_similar_notes.assert_not_called()
 
     def test_find_similar_notes_rejects_negative_threshold(self):
-        result = self._tool("zk_find_similar_notes")(note_id="abc", threshold=-0.1)
+        result = self._tool("slipbox_find_similar_notes")(note_id="abc", threshold=-0.1)
         assert result == self.THRESHOLD_ERROR, f"Expected {self.THRESHOLD_ERROR!r}, got {result!r}"
 
     def test_find_similar_notes_accepts_boundary_thresholds(self):
         """Threshold values 0.0 and 1.0 (inclusive) must pass the guard."""
         self.mock_zettel_service.find_similar_notes.return_value = []
-        self._tool("zk_find_similar_notes")(note_id="abc", threshold=0.0)
-        self._tool("zk_find_similar_notes")(note_id="abc", threshold=1.0)
+        self._tool("slipbox_find_similar_notes")(note_id="abc", threshold=0.0)
+        self._tool("slipbox_find_similar_notes")(note_id="abc", threshold=1.0)
         assert self.mock_zettel_service.find_similar_notes.call_count == 2, (
             "Both boundary calls should reach find_similar_notes"
         )
 
     def test_find_similar_notes_rejects_limit_zero(self):
-        result = self._tool("zk_find_similar_notes")(note_id="abc", threshold=self.VALID_THRESHOLD, limit=0)
+        result = self._tool("slipbox_find_similar_notes")(note_id="abc", threshold=self.VALID_THRESHOLD, limit=0)
         assert result == self.LIMIT_ERROR, f"Expected {self.LIMIT_ERROR!r}, got {result!r}"
         self.mock_zettel_service.find_similar_notes.assert_not_called()
 
     def test_find_similar_notes_rejects_negative_limit(self):
-        result = self._tool("zk_find_similar_notes")(note_id="abc", threshold=self.VALID_THRESHOLD, limit=-1)
+        result = self._tool("slipbox_find_similar_notes")(note_id="abc", threshold=self.VALID_THRESHOLD, limit=-1)
         assert result == self.LIMIT_ERROR, f"Expected {self.LIMIT_ERROR!r}, got {result!r}"
 
     def test_find_central_notes_rejects_limit_zero(self):
-        result = self._tool("zk_find_central_notes")(limit=0)
+        result = self._tool("slipbox_find_central_notes")(limit=0)
         assert result == self.LIMIT_ERROR, f"Expected {self.LIMIT_ERROR!r}, got {result!r}"
         self.mock_search_service.find_central_notes.assert_not_called()
 
     def test_find_central_notes_rejects_negative_limit(self):
-        result = self._tool("zk_find_central_notes")(limit=-5)
+        result = self._tool("slipbox_find_central_notes")(limit=-5)
         assert result == self.LIMIT_ERROR, f"Expected {self.LIMIT_ERROR!r}, got {result!r}"
 
     def test_get_cluster_report_rejects_min_score_above_one(self):
-        result = self._tool("zk_get_cluster_report")(min_score=1.5)
+        result = self._tool("slipbox_get_cluster_report")(min_score=1.5)
         assert result == self.MIN_SCORE_ERROR, f"Expected {self.MIN_SCORE_ERROR!r}, got {result!r}"
 
     def test_get_cluster_report_rejects_negative_min_score(self):
-        result = self._tool("zk_get_cluster_report")(min_score=-0.1)
+        result = self._tool("slipbox_get_cluster_report")(min_score=-0.1)
         assert result == self.MIN_SCORE_ERROR, f"Expected {self.MIN_SCORE_ERROR!r}, got {result!r}"
 
     def test_get_cluster_report_accepts_boundary_min_scores(self):
         """min_score values 0.0 and 1.0 must pass the guard and reach load_report."""
         self.mock_cluster_service.load_report.return_value = None
         calls_before = self.mock_cluster_service.load_report.call_count
-        result_low = self._tool("zk_get_cluster_report")(min_score=0.0)
-        result_high = self._tool("zk_get_cluster_report")(min_score=1.0)
+        result_low = self._tool("slipbox_get_cluster_report")(min_score=0.0)
+        result_high = self._tool("slipbox_get_cluster_report")(min_score=1.0)
         assert result_low != self.MIN_SCORE_ERROR, "min_score=0.0 should pass guard"
         assert result_high != self.MIN_SCORE_ERROR, "min_score=1.0 should pass guard"
         # Guard must not fire for boundary values; load_report called exactly once per call
@@ -469,7 +469,7 @@ class TestGuardClauses(MockServerBase):
         )
 
     def test_get_cluster_report_rejects_limit_zero(self):
-        result = self._tool("zk_get_cluster_report")(min_score=self.VALID_THRESHOLD, limit=0)
+        result = self._tool("slipbox_get_cluster_report")(min_score=self.VALID_THRESHOLD, limit=0)
         assert result == self.LIMIT_ERROR, f"Expected {self.LIMIT_ERROR!r}, got {result!r}"
 
 
@@ -524,11 +524,11 @@ class TestParseRefs:
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_update_note
+# Tool: slipbox_update_note
 # ---------------------------------------------------------------------------
 
 class TestUpdateNoteTool(MockServerBase):
-    """zk_update_note -- happy path, not-found, and invalid type."""
+    """slipbox_update_note -- happy path, not-found, and invalid type."""
 
     NOTE_ID = "update123"
     NOTE_TITLE = "Updated Title"
@@ -545,7 +545,7 @@ class TestUpdateNoteTool(MockServerBase):
         self.mock_zettel_service.update_note.return_value = self.mock_note
 
         # Act
-        result = self._tool("zk_update_note")(
+        result = self._tool("slipbox_update_note")(
             note_id=self.NOTE_ID, title=self.NOTE_TITLE
         )
 
@@ -558,7 +558,7 @@ class TestUpdateNoteTool(MockServerBase):
         self.mock_zettel_service.get_note.return_value = None
 
         # Act
-        result = self._tool("zk_update_note")(note_id="missing", title="X")
+        result = self._tool("slipbox_update_note")(note_id="missing", title="X")
 
         # Assert
         assert "Note not found: missing" in result, f"Expected not-found message, got {result!r}"
@@ -568,7 +568,7 @@ class TestUpdateNoteTool(MockServerBase):
         self.mock_zettel_service.get_note.return_value = self.mock_note
 
         # Act
-        result = self._tool("zk_update_note")(
+        result = self._tool("slipbox_update_note")(
             note_id=self.NOTE_ID, note_type="bogus"
         )
 
@@ -578,11 +578,11 @@ class TestUpdateNoteTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_delete_note
+# Tool: slipbox_delete_note
 # ---------------------------------------------------------------------------
 
 class TestDeleteNoteTool(MockServerBase):
-    """zk_delete_note -- happy path and not-found."""
+    """slipbox_delete_note -- happy path and not-found."""
 
     NOTE_ID = "delete123"
 
@@ -593,7 +593,7 @@ class TestDeleteNoteTool(MockServerBase):
         self.mock_zettel_service.get_note.return_value = mock_note
 
         # Act
-        result = self._tool("zk_delete_note")(note_id=self.NOTE_ID)
+        result = self._tool("slipbox_delete_note")(note_id=self.NOTE_ID)
 
         # Assert
         assert "deleted successfully" in result, f"Expected success message, got {result!r}"
@@ -604,18 +604,18 @@ class TestDeleteNoteTool(MockServerBase):
         self.mock_zettel_service.get_note.return_value = None
 
         # Act
-        result = self._tool("zk_delete_note")(note_id="missing")
+        result = self._tool("slipbox_delete_note")(note_id="missing")
 
         # Assert
         assert "Note not found: missing" in result, f"Expected not-found message, got {result!r}"
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_remove_link
+# Tool: slipbox_remove_link
 # ---------------------------------------------------------------------------
 
 class TestRemoveLinkTool(MockServerBase):
-    """zk_remove_link -- directional and bidirectional removal."""
+    """slipbox_remove_link -- directional and bidirectional removal."""
 
     SOURCE_ID = "src001"
     TARGET_ID = "tgt002"
@@ -628,7 +628,7 @@ class TestRemoveLinkTool(MockServerBase):
 
     def test_directional_returns_from_to_message(self):
         # Act
-        result = self._tool("zk_remove_link")(
+        result = self._tool("slipbox_remove_link")(
             source_id=self.SOURCE_ID,
             target_id=self.TARGET_ID,
             bidirectional=False,
@@ -641,7 +641,7 @@ class TestRemoveLinkTool(MockServerBase):
 
     def test_bidirectional_returns_between_message(self):
         # Act
-        result = self._tool("zk_remove_link")(
+        result = self._tool("slipbox_remove_link")(
             source_id=self.SOURCE_ID,
             target_id=self.TARGET_ID,
             bidirectional=True,
@@ -654,11 +654,11 @@ class TestRemoveLinkTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_delete_link
+# Tool: slipbox_delete_link
 # ---------------------------------------------------------------------------
 
 class TestDeleteLinkTool(MockServerBase):
-    """zk_delete_link -- strict deletion with existence check."""
+    """slipbox_delete_link -- strict deletion with existence check."""
 
     SOURCE_ID = "src001"
     TARGET_ID = "tgt002"
@@ -683,7 +683,7 @@ class TestDeleteLinkTool(MockServerBase):
         self.mock_zettel_service.remove_link.return_value = (source, None)
 
         # Act
-        result = self._tool("zk_delete_link")(
+        result = self._tool("slipbox_delete_link")(
             source_id=self.SOURCE_ID,
             target_id=self.TARGET_ID,
         )
@@ -707,7 +707,7 @@ class TestDeleteLinkTool(MockServerBase):
         )
 
         # Act
-        result = self._tool("zk_delete_link")(
+        result = self._tool("slipbox_delete_link")(
             source_id=self.SOURCE_ID,
             target_id=self.TARGET_ID,
         )
@@ -721,7 +721,7 @@ class TestDeleteLinkTool(MockServerBase):
         self.mock_zettel_service.get_note.return_value = None
 
         # Act
-        result = self._tool("zk_delete_link")(
+        result = self._tool("slipbox_delete_link")(
             source_id="missing",
             target_id=self.TARGET_ID,
         )
@@ -737,7 +737,7 @@ class TestDeleteLinkTool(MockServerBase):
         )
 
         # Act
-        result = self._tool("zk_delete_link")(
+        result = self._tool("slipbox_delete_link")(
             source_id=self.SOURCE_ID,
             target_id="missing",
         )
@@ -747,11 +747,11 @@ class TestDeleteLinkTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_get_linked_notes
+# Tool: slipbox_get_linked_notes
 # ---------------------------------------------------------------------------
 
 class TestGetLinkedNotesTool(MockServerBase):
-    """zk_get_linked_notes -- happy path, no links, invalid direction."""
+    """slipbox_get_linked_notes -- happy path, no links, invalid direction."""
 
     NOTE_ID = "center001"
 
@@ -774,7 +774,7 @@ class TestGetLinkedNotesTool(MockServerBase):
         self.mock_zettel_service.get_note.return_value = source_note
 
         # Act
-        result = self._tool("zk_get_linked_notes")(
+        result = self._tool("slipbox_get_linked_notes")(
             note_id=self.NOTE_ID, direction="outgoing"
         )
 
@@ -788,7 +788,7 @@ class TestGetLinkedNotesTool(MockServerBase):
         self.mock_zettel_service.get_linked_notes.return_value = []
 
         # Act
-        result = self._tool("zk_get_linked_notes")(
+        result = self._tool("slipbox_get_linked_notes")(
             note_id=self.NOTE_ID, direction="both"
         )
 
@@ -797,7 +797,7 @@ class TestGetLinkedNotesTool(MockServerBase):
 
     def test_invalid_direction_returns_error(self):
         # Act
-        result = self._tool("zk_get_linked_notes")(
+        result = self._tool("slipbox_get_linked_notes")(
             note_id=self.NOTE_ID, direction="sideways"
         )
 
@@ -808,11 +808,11 @@ class TestGetLinkedNotesTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_get_all_tags
+# Tool: slipbox_get_all_tags
 # ---------------------------------------------------------------------------
 
 class TestGetAllTagsTool(MockServerBase):
-    """zk_get_all_tags -- happy path and empty."""
+    """slipbox_get_all_tags -- happy path and empty."""
 
     def test_happy_path_returns_sorted_tag_list(self):
         # Arrange
@@ -823,7 +823,7 @@ class TestGetAllTagsTool(MockServerBase):
         self.mock_zettel_service.get_all_tags.return_value = [tag_a, tag_b, tag_c]
 
         # Act
-        result = self._tool("zk_get_all_tags")()
+        result = self._tool("slipbox_get_all_tags")()
 
         # Assert
         assert "Found 3 tags" in result, f"Expected tag count header, got {result!r}"
@@ -839,18 +839,18 @@ class TestGetAllTagsTool(MockServerBase):
         self.mock_zettel_service.get_all_tags.return_value = []
 
         # Act
-        result = self._tool("zk_get_all_tags")()
+        result = self._tool("slipbox_get_all_tags")()
 
         # Assert
         assert "No tags found" in result, f"Expected no-tags message, got {result!r}"
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_find_similar_notes
+# Tool: slipbox_find_similar_notes
 # ---------------------------------------------------------------------------
 
 class TestFindSimilarNotesTool(MockServerBase):
-    """zk_find_similar_notes -- happy path with results."""
+    """slipbox_find_similar_notes -- happy path with results."""
 
     NOTE_ID = "sim001"
     SIMILAR_SCORE = 0.85
@@ -869,7 +869,7 @@ class TestFindSimilarNotesTool(MockServerBase):
         ]
 
         # Act
-        result = self._tool("zk_find_similar_notes")(
+        result = self._tool("slipbox_find_similar_notes")(
             note_id=self.NOTE_ID, threshold=0.3
         )
 
@@ -880,11 +880,11 @@ class TestFindSimilarNotesTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_find_central_notes
+# Tool: slipbox_find_central_notes
 # ---------------------------------------------------------------------------
 
 class TestFindCentralNotesTool(MockServerBase):
-    """zk_find_central_notes -- happy path with results."""
+    """slipbox_find_central_notes -- happy path with results."""
 
     CONNECTION_COUNT = 12
 
@@ -902,7 +902,7 @@ class TestFindCentralNotesTool(MockServerBase):
         ]
 
         # Act
-        result = self._tool("zk_find_central_notes")(limit=5)
+        result = self._tool("slipbox_find_central_notes")(limit=5)
 
         # Assert
         assert "Central Hub" in result, f"Expected central note title, got {result!r}"
@@ -913,11 +913,11 @@ class TestFindCentralNotesTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_find_orphaned_notes
+# Tool: slipbox_find_orphaned_notes
 # ---------------------------------------------------------------------------
 
 class TestFindOrphanedNotesTool(MockServerBase):
-    """zk_find_orphaned_notes -- happy path and empty."""
+    """slipbox_find_orphaned_notes -- happy path and empty."""
 
     def test_happy_path_returns_formatted_orphan_list(self):
         # Arrange
@@ -929,7 +929,7 @@ class TestFindOrphanedNotesTool(MockServerBase):
         self.mock_search_service.find_orphaned_notes.return_value = [orphan]
 
         # Act
-        result = self._tool("zk_find_orphaned_notes")()
+        result = self._tool("slipbox_find_orphaned_notes")()
 
         # Assert
         assert "Lonely Note" in result, f"Expected orphan title, got {result!r}"
@@ -941,7 +941,7 @@ class TestFindOrphanedNotesTool(MockServerBase):
         self.mock_search_service.find_orphaned_notes.return_value = []
 
         # Act
-        result = self._tool("zk_find_orphaned_notes")()
+        result = self._tool("slipbox_find_orphaned_notes")()
 
         # Assert
         assert result == "No orphaned notes found.", (
@@ -950,11 +950,11 @@ class TestFindOrphanedNotesTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_list_notes_by_date
+# Tool: slipbox_list_notes_by_date
 # ---------------------------------------------------------------------------
 
 class TestListNotesByDateTool(MockServerBase):
-    """zk_list_notes_by_date -- happy path, no results, and invalid date."""
+    """slipbox_list_notes_by_date -- happy path, no results, and invalid date."""
 
     def _make_dated_note(self, note_id, title, date_str):
         note = MagicMock()
@@ -972,7 +972,7 @@ class TestListNotesByDateTool(MockServerBase):
         self.mock_search_service.find_notes_by_date_range.return_value = [note]
 
         # Act
-        result = self._tool("zk_list_notes_by_date")(
+        result = self._tool("slipbox_list_notes_by_date")(
             start_date="2023-06-01", end_date="2023-06-30", limit=10
         )
 
@@ -986,7 +986,7 @@ class TestListNotesByDateTool(MockServerBase):
         self.mock_search_service.find_notes_by_date_range.return_value = []
 
         # Act
-        result = self._tool("zk_list_notes_by_date")(
+        result = self._tool("slipbox_list_notes_by_date")(
             start_date="2099-01-01", end_date="2099-12-31"
         )
 
@@ -995,18 +995,18 @@ class TestListNotesByDateTool(MockServerBase):
 
     def test_invalid_date_returns_parsing_error(self):
         # Act
-        result = self._tool("zk_list_notes_by_date")(start_date="not-a-date")
+        result = self._tool("slipbox_list_notes_by_date")(start_date="not-a-date")
 
         # Assert
         assert "Error parsing date" in result, f"Expected date parsing error, got {result!r}"
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_rebuild_index
+# Tool: slipbox_rebuild_index
 # ---------------------------------------------------------------------------
 
 class TestRebuildIndexTool(MockServerBase):
-    """zk_rebuild_index -- happy path."""
+    """slipbox_rebuild_index -- happy path."""
 
     NOTE_COUNT = 42
 
@@ -1015,7 +1015,7 @@ class TestRebuildIndexTool(MockServerBase):
         self.mock_zettel_service.get_all_notes.return_value = [MagicMock()] * self.NOTE_COUNT
 
         # Act
-        result = self._tool("zk_rebuild_index")()
+        result = self._tool("slipbox_rebuild_index")()
 
         # Assert
         assert "rebuilt successfully" in result, f"Expected success message, got {result!r}"
@@ -1025,11 +1025,11 @@ class TestRebuildIndexTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_get_cluster_report (happy path)
+# Tool: slipbox_get_cluster_report (happy path)
 # ---------------------------------------------------------------------------
 
 class TestGetClusterReportTool(MockServerBase):
-    """zk_get_cluster_report -- happy path with results."""
+    """slipbox_get_cluster_report -- happy path with results."""
 
     def _make_report_with_clusters(self):
         from slipbox_mcp.services.cluster_service import ClusterCandidate, ClusterReport
@@ -1062,7 +1062,7 @@ class TestGetClusterReportTool(MockServerBase):
         self.mock_cluster_service.load_report.return_value = report
 
         # Act
-        result = self._tool("zk_get_cluster_report")(min_score=0.5)
+        result = self._tool("slipbox_get_cluster_report")(min_score=0.5)
 
         # Assert
         assert "Poetry & Craft" in result, f"Expected cluster title, got {result!r}"
@@ -1075,18 +1075,18 @@ class TestGetClusterReportTool(MockServerBase):
         self.mock_cluster_service.load_report.return_value = report
 
         # Act
-        result = self._tool("zk_get_cluster_report")(min_score=0.99)
+        result = self._tool("slipbox_get_cluster_report")(min_score=0.99)
 
         # Assert
         assert "No clusters found" in result, f"Expected no-clusters message, got {result!r}"
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_refresh_clusters
+# Tool: slipbox_refresh_clusters
 # ---------------------------------------------------------------------------
 
 class TestRefreshClustersTool(MockServerBase):
-    """zk_refresh_clusters -- happy path."""
+    """slipbox_refresh_clusters -- happy path."""
 
     def test_happy_path_returns_stats(self):
         from slipbox_mcp.services.cluster_service import ClusterCandidate, ClusterReport
@@ -1117,7 +1117,7 @@ class TestRefreshClustersTool(MockServerBase):
         self.mock_cluster_service.save_report.return_value = "/tmp/report.json"
 
         # Act
-        result = self._tool("zk_refresh_clusters")()
+        result = self._tool("slipbox_refresh_clusters")()
 
         # Assert
         assert "Cluster analysis complete" in result, f"Expected success header, got {result!r}"
@@ -1126,11 +1126,11 @@ class TestRefreshClustersTool(MockServerBase):
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_dismiss_cluster
+# Tool: slipbox_dismiss_cluster
 # ---------------------------------------------------------------------------
 
 class TestDismissClusterTool(MockServerBase):
-    """zk_dismiss_cluster -- happy path and not-found."""
+    """slipbox_dismiss_cluster -- happy path and not-found."""
 
     def _make_report(self, cluster_ids):
         from slipbox_mcp.services.cluster_service import ClusterCandidate, ClusterReport
@@ -1161,7 +1161,7 @@ class TestDismissClusterTool(MockServerBase):
         self.mock_cluster_service.load_report.return_value = self._make_report([CLUSTER_ID])
 
         # Act
-        result = self._tool("zk_dismiss_cluster")(cluster_id=CLUSTER_ID)
+        result = self._tool("slipbox_dismiss_cluster")(cluster_id=CLUSTER_ID)
 
         # Assert
         assert "dismissed" in result, f"Expected dismiss confirmation, got {result!r}"
@@ -1173,7 +1173,7 @@ class TestDismissClusterTool(MockServerBase):
         self.mock_cluster_service.load_report.return_value = self._make_report(["existing"])
 
         # Act
-        result = self._tool("zk_dismiss_cluster")(cluster_id="nonexistent")
+        result = self._tool("slipbox_dismiss_cluster")(cluster_id="nonexistent")
 
         # Assert
         assert "not found" in result, f"Expected not-found message, got {result!r}"
@@ -1183,18 +1183,18 @@ class TestDismissClusterTool(MockServerBase):
         self.mock_cluster_service.load_report.return_value = None
 
         # Act
-        result = self._tool("zk_dismiss_cluster")(cluster_id="any")
+        result = self._tool("slipbox_dismiss_cluster")(cluster_id="any")
 
         # Assert
         assert "No cluster report found" in result, f"Expected no-report message, got {result!r}"
 
 
 # ---------------------------------------------------------------------------
-# Tool: zk_create_structure_from_cluster
+# Tool: slipbox_create_structure_from_cluster
 # ---------------------------------------------------------------------------
 
 class TestCreateStructureFromClusterTool(MockServerBase):
-    """zk_create_structure_from_cluster -- happy path and not-found."""
+    """slipbox_create_structure_from_cluster -- happy path and not-found."""
 
     def _make_report(self, cluster_id, note_infos):
         from slipbox_mcp.services.cluster_service import ClusterCandidate, ClusterReport
@@ -1229,7 +1229,7 @@ class TestCreateStructureFromClusterTool(MockServerBase):
         self.mock_zettel_service.create_link.return_value = (MagicMock(), MagicMock())
 
         # Act
-        result = self._tool("zk_create_structure_from_cluster")(
+        result = self._tool("slipbox_create_structure_from_cluster")(
             cluster_id=CLUSTER_ID
         )
 
@@ -1245,7 +1245,7 @@ class TestCreateStructureFromClusterTool(MockServerBase):
         self.mock_cluster_service.load_report.return_value = report
 
         # Act
-        result = self._tool("zk_create_structure_from_cluster")(
+        result = self._tool("slipbox_create_structure_from_cluster")(
             cluster_id="nonexistent"
         )
 
@@ -1257,7 +1257,7 @@ class TestCreateStructureFromClusterTool(MockServerBase):
         self.mock_cluster_service.load_report.return_value = None
 
         # Act
-        result = self._tool("zk_create_structure_from_cluster")(cluster_id="any")
+        result = self._tool("slipbox_create_structure_from_cluster")(cluster_id="any")
 
         # Assert
         assert "No cluster report found" in result, f"Expected no-report message, got {result!r}"

--- a/tests/test_semantic_links.py
+++ b/tests/test_semantic_links.py
@@ -611,7 +611,7 @@ Test content for parsing links from markdown.
             
     # Fix for test_mcp_get_linked_notes_tool
     def test_mcp_get_linked_notes_tool(self, zettel_service):
-        """Test that zk_get_linked_notes correctly displays semantic link types."""
+        """Test that slipbox_get_linked_notes correctly displays semantic link types."""
         # Create test notes
         central_note = zettel_service.create_note(
             title="MCP Tool Test Central Note",
@@ -639,8 +639,8 @@ Test content for parsing links from markdown.
         server.zettel_service = zettel_service
         
         # Access the tool function via MCP's tool registry
-        zk_get_linked_notes = server.mcp._tool_manager.get_tool("zk_get_linked_notes").fn
-        result = zk_get_linked_notes(
+        slipbox_get_linked_notes = server.mcp._tool_manager.get_tool("slipbox_get_linked_notes").fn
+        result = slipbox_get_linked_notes(
             note_id=central_note.id,
             direction="outgoing"
         )
@@ -653,7 +653,7 @@ Test content for parsing links from markdown.
 
     # Fix for test_mcp_create_link_tool
     def test_mcp_create_link_tool(self, zettel_service):
-        """Test that zk_create_link correctly creates links with semantic types."""
+        """Test that slipbox_create_link correctly creates links with semantic types."""
         # Create test notes
         source_note = zettel_service.create_note(
             title="MCP Create Link Source",
@@ -673,8 +673,8 @@ Test content for parsing links from markdown.
         server.zettel_service = zettel_service  # Use our test zettel_service
         
         # Access the tool function via MCP's tool registry
-        zk_create_link = server.mcp._tool_manager.get_tool("zk_create_link").fn
-        result = zk_create_link(
+        slipbox_create_link = server.mcp._tool_manager.get_tool("slipbox_create_link").fn
+        result = slipbox_create_link(
             source_id=source_note.id,
             target_id=target_note.id,
             link_type="supports",


### PR DESCRIPTION
## Summary

Addresses remaining items from #1 (Week 1: Polish & Prepare).

- **Rename `zk_` tool prefix to `slipbox_`**: All 18 MCP tool names, function names, description constants, and references across server code, tests, evals, and docs
- **Fix README accuracy**: Python version (3.10+ not 3.11+), CLI command (`slipbox` not `zk`), tool name references
- **Add troubleshooting entries**: `ZETTELKASTEN_*` env var migration, hardcoded cluster report path, macOS-only install scripts, CWD-relative default paths
- **Add `.github/FUNDING.yml`** for GitHub Sponsors button
- **Draft Reddit launch post** with per-subreddit targeting notes

## Test plan

- [x] 296 unit + contract tests passing
- [x] ruff clean
- [x] Verified no stray `zk_` references remain in source/test/doc files (only `.egg-info` build artifact, regenerated on install)

Closes #1 (remaining items: GitHub Sponsors tiers + Twitter/X are external platform tasks)