### PR TITLE
fix: OR multi-word FTS5 search terms instead of exact-phrase match

### DIFF
--- a/src/slipbox_mcp/services/search_service.py
+++ b/src/slipbox_mcp/services/search_service.py
@@ -14,6 +14,30 @@ from slipbox_mcp.storage.note_repository import _NOTE_EAGER_LOADS
 
 logger = logging.getLogger(__name__)
 
+
+def _build_fts_match(query: str, column: Optional[str] = None) -> str:
+    """Build an FTS5 MATCH expression from a free-text query.
+
+    Each whitespace-separated token is wrapped in double quotes (so any FTS5
+    special characters inside a token are treated as literal text) and the
+    tokens are combined with OR. OR maximizes recall -- a note matches if it
+    contains *any* term -- while BM25 ranking still floats notes that match
+    more terms to the top.
+
+    Wrapping the whole query in quotes instead would produce a single FTS5
+    phrase query, which only matches when the tokens appear contiguously and
+    in order. That is why multi-word searches previously returned nothing.
+
+    ``column`` optionally scopes each term to a single FTS5 column
+    (e.g. ``title`` or ``content``).
+    """
+    tokens = query.split()
+    if not tokens:
+        return ""
+    prefix = f"{column}:" if column else ""
+    return " OR ".join(f'{prefix}"{tok.replace(chr(34), chr(34) * 2)}"' for tok in tokens)
+
+
 @dataclass
 class SearchResult:
     """A search result with a note and its relevance score."""
@@ -70,13 +94,12 @@ class SearchService:
 
         repository = self.zettel_service.repository
 
-        escaped = query.replace('"', '""')
         if include_title and include_content:
-            fts_query = f'"{escaped}"'
+            fts_query = _build_fts_match(query)
         elif include_title:
-            fts_query = f'title:"{escaped}"'
+            fts_query = _build_fts_match(query, column="title")
         else:
-            fts_query = f'content:"{escaped}"'
+            fts_query = _build_fts_match(query, column="content")
 
         rows = self._run_fts5_query(fts_query)
 
@@ -172,8 +195,7 @@ class SearchService:
                     for n in notes
                 ]
 
-            escaped = query_text.replace('"', '""')
-            fts_query = f'"{escaped}"'
+            fts_query = _build_fts_match(query_text)
 
         fts_rows = self._run_fts5_query(fts_query)
 

--- a/src/slipbox_mcp/services/search_service.py
+++ b/src/slipbox_mcp/services/search_service.py
@@ -29,13 +29,20 @@ def _build_fts_match(query: str, column: Optional[str] = None) -> str:
     in order. That is why multi-word searches previously returned nothing.
 
     ``column`` optionally scopes each term to a single FTS5 column
-    (e.g. ``title`` or ``content``).
+    (e.g. ``title`` or ``content``). Phrase search is intentionally
+    unsupported -- every token is matched independently.
     """
     tokens = query.split()
     if not tokens:
         return ""
     prefix = f"{column}:" if column else ""
-    return " OR ".join(f'{prefix}"{tok.replace(chr(34), chr(34) * 2)}"' for tok in tokens)
+    quoted = []
+    for tok in tokens:
+        # Inside an FTS5 double-quoted string the only character needing
+        # escaping is the double quote itself, escaped by doubling it.
+        escaped = tok.replace('"', '""')
+        quoted.append(f'{prefix}"{escaped}"')
+    return " OR ".join(quoted)
 
 
 @dataclass

--- a/src/slipbox_mcp/services/search_service.py
+++ b/src/slipbox_mcp/services/search_service.py
@@ -101,6 +101,12 @@ class SearchService:
         else:
             fts_query = _build_fts_match(query, column="content")
 
+        # A whitespace-only query yields no tokens; return [] explicitly rather
+        # than letting an empty MATCH expression fall through to the FTS5
+        # syntax-error catch (which would log a misleading "syntax error").
+        if not fts_query:
+            return []
+
         rows = self._run_fts5_query(fts_query)
 
         results = []
@@ -188,7 +194,10 @@ class SearchService:
             db_notes = session.execute(query).unique().scalars().all()
             candidate_ids = {db_note.id: db_note for db_note in db_notes}
 
-            if not query_text:
+            # Treat a missing or whitespace-only query_text as "no text filter":
+            # return the metadata-matched candidates rather than running an empty
+            # MATCH (which would swallow a misleading FTS5 syntax error to []).
+            if not query_text or not query_text.strip():
                 notes = [repository._db_note_to_note(n) for n in db_notes]
                 return [
                     SearchResult(note=n, score=1.0, matched_terms=set(), matched_context="")

--- a/tests/test_fts5_search.py
+++ b/tests/test_fts5_search.py
@@ -96,6 +96,33 @@ def test_search_by_text_fts_special_chars_do_not_crash(zettel_service, search_se
     assert isinstance(search_service.search_by_text("*wildcard"), list)
 
 
+def test_search_by_text_multi_word_query_matches_any_term(zettel_service, search_service):
+    """Multi-word queries must OR their terms, not require an exact phrase.
+
+    Regression: queries were wrapped in quotes and run as a single FTS5 phrase,
+    so any multi-word search ("writing thinking", "poetry craft writing")
+    returned nothing unless the words appeared contiguously and in order.
+    """
+    writing_note = zettel_service.create_note(
+        title="On Writing",
+        content="A note about the craft of writing prose.",
+        tags=[],
+    )
+    thinking_note = zettel_service.create_note(
+        title="On Thinking",
+        content="A note about thinking clearly and reasoning.",
+        tags=[],
+    )
+
+    # The two words never appear adjacent in either note, so a phrase query
+    # would return []. An OR query must surface both notes.
+    results = search_service.search_by_text("writing thinking")
+    found_ids = {r.note.id for r in results}
+
+    assert writing_note.id in found_ids
+    assert thinking_note.id in found_ids
+
+
 def test_search_combined_text_uses_bm25(zettel_service, search_service):
     """search_combined with text must return BM25-ranked results, not Python-scored."""
     note_a = zettel_service.create_note(

--- a/tests/test_fts5_search.py
+++ b/tests/test_fts5_search.py
@@ -123,6 +123,33 @@ def test_search_by_text_multi_word_query_matches_any_term(zettel_service, search
     assert thinking_note.id in found_ids
 
 
+def test_search_by_text_whitespace_only_query_returns_empty(zettel_service, search_service):
+    """A whitespace-only query has no tokens and must return [] without hitting FTS5.
+
+    Regression: such a query is truthy, so it bypasses the `if not query` guard,
+    builds an empty MATCH expression, and previously relied on the FTS5
+    syntax-error catch (which logged a misleading "syntax error") to return [].
+    """
+    zettel_service.create_note(title="Any Note", content="Some content.", tags=[])
+    assert search_service.search_by_text("   ") == []
+    assert search_service.search_by_text("\t\n") == []
+
+
+def test_search_combined_whitespace_text_treated_as_no_text(zettel_service, search_service):
+    """Whitespace-only query_text must behave like no text: return metadata matches."""
+    note = zettel_service.create_note(
+        title="Tagged Note",
+        content="Some content.",
+        note_type=NoteType.PERMANENT,
+        tags=["unique-ws-tag"],
+    )
+    results = search_service.search_combined(query_text="   ", tags=["unique-ws-tag"])
+
+    assert len(results) == 1
+    assert results[0].note.id == note.id
+    assert results[0].score == 1.0
+
+
 def test_search_combined_text_uses_bm25(zettel_service, search_service):
     """search_combined with text must return BM25-ranked results, not Python-scored."""
     note_a = zettel_service.create_note(


### PR DESCRIPTION
## Problem

Multi-word searches returned almost nothing. Single-word queries like `knowledge` worked (8 hits), but every multi-word query — `writing thinking`, `poetry craft writing practice`, `attention cognitive load` — dead-ended with "No matching notes found."

## Root cause

`search_by_text` and `search_combined` wrapped the entire query in double quotes:

```python
fts_query = f'"{escaped}"'   # "writing thinking"
```

In SQLite FTS5 a double-quoted string is a phrase query — it matches only documents where the tokens appear contiguously and in order. So `"knowledge"` (one token) matched anything containing the word, but `"writing thinking"` required that exact adjacent phrase, which essentially never occurs. This is stricter than the AND it appeared to be; AND would at least match both words anywhere in a note.

## Fix

Added `_build_fts_match()`, which tokenizes the query and OR-joins each token (quoted individually so FTS5 operators inside user input can't break the syntax):

```
"writing" OR "thinking"
```

OR maximizes recall — a note matches if it contains any term — while BM25 ranking still floats notes matching more terms to the top. Both call sites use it, including the `title:`/`content:` column-scoped variants.

## Tests

- New regression test `test_search_by_text_multi_word_query_matches_any_term`: two notes that never have the words adjacent; the old phrase query returned `[]`, the OR query surfaces both.
- `tests/test_fts5_search.py` (14) plus search/integration/mcp suites (97) all pass.
