### PR TITLE
fix: sweep inbound references on delete; add prune-links command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,21 @@ Run the test suite to verify your setup:
 uv run pytest tests/
 ```
 
+### Working in a git worktree
+
+This package is installed editable, so each worktree needs its own venv;
+otherwise it imports the main checkout's source and you test the wrong code.
+Use the helper, which creates the worktree under `.worktrees/` and syncs it:
+
+```bash
+scripts/new-worktree.sh fix/my-change            # branches from origin/main
+scripts/new-worktree.sh fix/my-change my-base    # or from another ref
+```
+
+Then `cd` into the printed path and run `uv run pytest`. (A `conftest.py`
+path shim guards the case where the venv hasn't been synced, but a per-worktree
+venv is the real fix.)
+
 ## Project Structure
 
 ```text

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,23 @@
 """Root conftest -- shared fixtures available to both tests/ and evals/."""
+# Path shim: force this tree's src/ to the front of sys.path BEFORE any
+# slipbox_mcp import resolves. The repo is installed editable in a shared
+# .venv whose .pth points at the MAIN checkout, so a worktree's pytest run
+# would otherwise import main's source while collecting the worktree's tests
+# -- silently testing the wrong code. Prepending the local src/ overrides
+# that. No-op when src/ isn't beside this file.
+import sys as _sys
+from pathlib import Path as _Path
+
+_local_src = _Path(__file__).resolve().parent / "src"
+if _local_src.is_dir():
+    _src_str = str(_local_src)
+    if _sys.path and _sys.path[0] == _src_str:
+        pass
+    else:
+        # Drop any existing occurrence, then pin to front.
+        _sys.path = [p for p in _sys.path if p != _src_str]
+        _sys.path.insert(0, _src_str)
+
 import tempfile
 from pathlib import Path
 

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# new-worktree.sh — Create a git worktree under .worktrees/<name> and sync
+# its own venv, so each worktree imports its own src/ instead of the main
+# checkout's editable install. Works when invoked from any worktree.
+#
+# Usage: scripts/new-worktree.sh <name> [base-ref]
+#   <name>      branch + directory name (e.g. fix/foo -> .worktrees/foo)
+#   [base-ref]  ref to branch from (default: origin/main)
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <name> [base-ref]" >&2
+  exit 2
+fi
+
+name="$1"
+base_ref="${2:-origin/main}"
+
+# Resolve the MAIN working tree (first entry of `git worktree list`), so
+# .worktrees/ always sits beside the primary checkout regardless of cwd.
+main_tree="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+if [[ -z "${main_tree}" ]]; then
+  echo "error: not inside a git repository" >&2
+  exit 1
+fi
+
+# Directory name is the last path segment of the branch name.
+dir_name="${name##*/}"
+dest="${main_tree}/.worktrees/${dir_name}"
+
+if [[ -e "${dest}" ]]; then
+  echo "error: ${dest} already exists" >&2
+  exit 1
+fi
+
+# Find uv even when it isn't on the non-login PATH.
+uv_bin="$(command -v uv || true)"
+[[ -z "${uv_bin}" && -x "${HOME}/.local/bin/uv" ]] && uv_bin="${HOME}/.local/bin/uv"
+if [[ -z "${uv_bin}" ]]; then
+  echo "error: uv not found (looked on PATH and ~/.local/bin)" >&2
+  exit 1
+fi
+
+echo "Creating worktree ${dest} on branch ${name} from ${base_ref}..."
+git fetch --quiet origin 2>/dev/null || true
+
+# Reuse the branch if it already exists; otherwise create it from base_ref.
+if git show-ref --verify --quiet "refs/heads/${name}"; then
+  git worktree add "${dest}" "${name}"
+else
+  git worktree add -b "${name}" "${dest}" "${base_ref}"
+fi
+
+echo "Syncing venv with all extras..."
+( cd "${dest}" && "${uv_bin}" sync --all-extras )
+
+echo
+echo "Done. Worktree ready:"
+echo "  cd ${dest}"
+echo "  uv run pytest"

--- a/src/slipbox_mcp/cli.py
+++ b/src/slipbox_mcp/cli.py
@@ -347,13 +347,26 @@ def cmd_prune_links(args):
             print("\nRun with --fix to remove them.")
             sys.exit(1)
 
-        pruned = repo.prune_dangling_links()
-        if not pruned:
+        pruned, failed = repo.prune_dangling_links()
+        if not pruned and not failed:
             print("No dangling links found.")
             return
-        print(f"Pruned {len(pruned)} dangling link(s):\n")
-        for source_id, target_id, link_type in pruned:
-            print(f"  {source_id}  --{link_type}-->  {target_id}")
+        if pruned:
+            print(f"Pruned {len(pruned)} dangling link(s):\n")
+            for source_id, target_id, link_type in pruned:
+                print(f"  {source_id}  --{link_type}-->  {target_id}")
+        if failed:
+            print(
+                f"\nWARNING: {len(failed)} dangling link(s) could NOT be removed "
+                f"(note rewrite failed); they are still on disk:",
+                file=sys.stderr,
+            )
+            for source_id, target_id, link_type in failed:
+                print(
+                    f"  {source_id}  --{link_type}-->  {target_id} (STILL DANGLING)",
+                    file=sys.stderr,
+                )
+            sys.exit(1)
         print("\nDone.")
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/src/slipbox_mcp/cli.py
+++ b/src/slipbox_mcp/cli.py
@@ -325,6 +325,41 @@ def cmd_audit_references(args):
         sys.exit(1)
 
 
+def cmd_prune_links(args):
+    """Find links pointing at deleted notes; optionally remove them.
+
+    Without --fix, lists every dangling link (source -> missing target).
+    With --fix, rewrites the affected notes to drop those links. Exits
+    non-zero when dangling links are found in dry-run mode, so the command
+    is usable as a CI gate.
+    """
+    try:
+        repo = NoteRepository()
+
+        if not args.fix:
+            dangling = repo.find_dangling_links()
+            if not dangling:
+                print("No dangling links found.")
+                return
+            print(f"Found {len(dangling)} dangling link(s):\n")
+            for source_id, target_id, link_type in dangling:
+                print(f"  {source_id}  --{link_type}-->  {target_id} (missing)")
+            print("\nRun with --fix to remove them.")
+            sys.exit(1)
+
+        pruned = repo.prune_dangling_links()
+        if not pruned:
+            print("No dangling links found.")
+            return
+        print(f"Pruned {len(pruned)} dangling link(s):\n")
+        for source_id, target_id, link_type in pruned:
+            print(f"  {source_id}  --{link_type}-->  {target_id}")
+        print("\nDone.")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
 def cmd_tags(args):
     """List all tags."""
     try:
@@ -393,6 +428,17 @@ def main():
         help="Apply a fix: 'downgrade' converts offenders to type=permanent",
     )
 
+    # prune-links
+    p_prune = subparsers.add_parser(
+        "prune-links",
+        help="Find and remove links pointing at deleted notes"
+    )
+    p_prune.add_argument(
+        "--fix",
+        action="store_true",
+        help="Remove the dangling links (default: list only)",
+    )
+
     args = parser.parse_args()
 
     from slipbox_mcp.config import config
@@ -414,6 +460,7 @@ def main():
         "export": cmd_export,
         "tags": cmd_tags,
         "audit-references": cmd_audit_references,
+        "prune-links": cmd_prune_links,
     }
 
     commands[args.command](args)

--- a/src/slipbox_mcp/storage/note_repository.py
+++ b/src/slipbox_mcp/storage/note_repository.py
@@ -590,6 +590,11 @@ class NoteRepository(Repository[Note]):
         filesystem is the source of truth, so leaving a dangling ``[[id]]``
         in a referrer's body would let rebuild_index resurrect the link into
         the DB on the next rebuild.
+
+        Raises:
+            ReferrerSweepError: the note was deleted, but one or more
+                referrers could not be swept and still carry dangling links.
+                Run ``slipbox prune-links --fix`` to clean them.
         """
         file_path = self.notes_dir / f"{id}.md"
         if not file_path.exists():

--- a/src/slipbox_mcp/storage/note_repository.py
+++ b/src/slipbox_mcp/storage/note_repository.py
@@ -562,12 +562,23 @@ class NoteRepository(Repository[Note]):
         return note
 
     def delete(self, id: str) -> None:
-        """Delete a note by ID."""
+        """Delete a note by ID.
+
+        Also sweeps inbound references: any note whose ``## Links`` section
+        points at the deleted note is rewritten without that link. The
+        filesystem is the source of truth, so leaving a dangling ``[[id]]``
+        in a referrer's body would let rebuild_index resurrect the link into
+        the DB on the next rebuild.
+        """
         file_path = self.notes_dir / f"{id}.md"
         if not file_path.exists():
             raise ValueError(f"Note with ID {id} does not exist")
 
         with self.file_lock:
+            # Collect referrers BEFORE deleting, while the DB index still
+            # knows who links to this note.
+            referrers = self.find_linked_notes(id, direction="incoming")
+
             original_content = file_path.read_text(encoding="utf-8")
 
             try:
@@ -590,6 +601,27 @@ class NoteRepository(Repository[Note]):
                     logger.error("Failed to restore file %s after DB error", file_path)
                 logger.error("DB cleanup failed for note %s, file restored: %s", id, e)
                 raise
+
+            # Sweep dead links out of each referrer. Re-read from disk so we
+            # rewrite the authoritative full link set, then let update()
+            # regenerate the ## Links block via note_to_markdown.
+            for referrer in referrers:
+                if referrer.id == id:
+                    continue
+                fresh = self.get(referrer.id)
+                if fresh is None:
+                    continue
+                remaining = [lnk for lnk in fresh.links if lnk.target_id != id]
+                if len(remaining) == len(fresh.links):
+                    continue
+                fresh.links = remaining
+                try:
+                    self.update(fresh)
+                except Exception as e:
+                    logger.error(
+                        "Failed to sweep dead link to %s from referrer %s: %s",
+                        id, referrer.id, e,
+                    )
 
     def search(self, **kwargs: Any) -> List[Note]:
         """Search for notes based on criteria."""
@@ -772,3 +804,47 @@ class NoteRepository(Repository[Note]):
                 continue
             result.append((self._db_note_to_note(db_note), rank_map[note_id]))
         return result
+
+    def find_dangling_links(self) -> List[tuple]:
+        """Find links whose target note no longer exists on disk.
+
+        Read-only. Returns (source_id, target_id, link_type) tuples for every
+        link pointing at a note id with no corresponding markdown file. These
+        are the stubs left behind by deletes that predate referrer-sweeping,
+        or by hand-editing.
+        """
+        existing = {p.stem for p in self.notes_dir.glob("*.md")}
+        dangling: List[tuple] = []
+        for note in self.get_all():
+            for link in note.links:
+                if link.target_id not in existing:
+                    dangling.append(
+                        (note.id, link.target_id, link.link_type.value)
+                    )
+        return dangling
+
+    def prune_dangling_links(self) -> List[tuple]:
+        """Remove links pointing at non-existent notes; return what was pruned.
+
+        Rewrites each affected note via update(), which regenerates the
+        ## Links block from the surviving links. Returns the same
+        (source_id, target_id, link_type) tuples that find_dangling_links
+        would report, for the notes actually rewritten.
+        """
+        existing = {p.stem for p in self.notes_dir.glob("*.md")}
+        pruned: List[tuple] = []
+        for note in self.get_all():
+            live = [lnk for lnk in note.links if lnk.target_id in existing]
+            if len(live) == len(note.links):
+                continue
+            for lnk in note.links:
+                if lnk.target_id not in existing:
+                    pruned.append((note.id, lnk.target_id, lnk.link_type.value))
+            note.links = live
+            try:
+                self.update(note)
+            except Exception as e:
+                logger.error(
+                    "Failed to prune dangling links from note %s: %s", note.id, e
+                )
+        return pruned

--- a/src/slipbox_mcp/storage/note_repository.py
+++ b/src/slipbox_mcp/storage/note_repository.py
@@ -23,6 +23,27 @@ from slipbox_mcp.storage.base import Repository
 logger = logging.getLogger(__name__)
 
 
+class ReferrerSweepError(Exception):
+    """A note was deleted, but one or more referrers could not be swept.
+
+    The deletion itself succeeded (file removed, DB rows gone), but at least
+    one referrer still carries a dangling ``[[id]]`` that would be resurrected
+    on the next rebuild_index. The message names the affected referrers and
+    the recovery command. Callers should surface this rather than treat the
+    delete as fully clean.
+    """
+
+    def __init__(self, deleted_id: str, failures: List[tuple]):
+        self.deleted_id = deleted_id
+        self.failures = failures
+        detail = "; ".join(f"{ref} ({reason})" for ref, reason in failures)
+        super().__init__(
+            f"Note {deleted_id} was deleted, but {len(failures)} referrer(s) "
+            f"still carry dead links and will reappear on rebuild: {detail}. "
+            f"Run `slipbox prune-links --fix` to clean them."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Markdown parsing helpers (module-level, no instance state needed)
 # ---------------------------------------------------------------------------
@@ -604,12 +625,23 @@ class NoteRepository(Repository[Note]):
 
             # Sweep dead links out of each referrer. Re-read from disk so we
             # rewrite the authoritative full link set, then let update()
-            # regenerate the ## Links block via note_to_markdown.
+            # regenerate the ## Links block via note_to_markdown. A failure on
+            # one referrer must not abort the others, so collect failures and
+            # raise once at the end rather than swallowing them silently.
+            sweep_failures: List[tuple] = []
             for referrer in referrers:
                 if referrer.id == id:
                     continue
                 fresh = self.get(referrer.id)
                 if fresh is None:
+                    # The index named this referrer, but its file is gone: a
+                    # DB/filesystem desync. There is no file to clean, but the
+                    # stale state is worth a signal rather than a silent skip.
+                    logger.error(
+                        "Index lists %s as a referrer of %s but its file is "
+                        "missing (DB/filesystem desync); skipping sweep",
+                        referrer.id, id,
+                    )
                     continue
                 remaining = [lnk for lnk in fresh.links if lnk.target_id != id]
                 if len(remaining) == len(fresh.links):
@@ -622,6 +654,10 @@ class NoteRepository(Repository[Note]):
                         "Failed to sweep dead link to %s from referrer %s: %s",
                         id, referrer.id, e,
                     )
+                    sweep_failures.append((referrer.id, str(e)))
+
+            if sweep_failures:
+                raise ReferrerSweepError(id, sweep_failures)
 
     def search(self, **kwargs: Any) -> List[Note]:
         """Search for notes based on criteria."""
@@ -823,28 +859,37 @@ class NoteRepository(Repository[Note]):
                     )
         return dangling
 
-    def prune_dangling_links(self) -> List[tuple]:
-        """Remove links pointing at non-existent notes; return what was pruned.
+    def prune_dangling_links(self) -> tuple[List[tuple], List[tuple]]:
+        """Remove links pointing at non-existent notes.
 
         Rewrites each affected note via update(), which regenerates the
-        ## Links block from the surviving links. Returns the same
-        (source_id, target_id, link_type) tuples that find_dangling_links
-        would report, for the notes actually rewritten.
+        ## Links block from the surviving links.
+
+        Returns ``(pruned, failed)``: two lists of
+        (source_id, target_id, link_type) tuples. A tuple lands in ``pruned``
+        only after its note is successfully rewritten; if update() throws, the
+        note's dead links go to ``failed`` instead. The return value never
+        reports a prune that did not actually happen.
         """
         existing = {p.stem for p in self.notes_dir.glob("*.md")}
         pruned: List[tuple] = []
+        failed: List[tuple] = []
         for note in self.get_all():
-            live = [lnk for lnk in note.links if lnk.target_id in existing]
-            if len(live) == len(note.links):
+            dead = [
+                (note.id, lnk.target_id, lnk.link_type.value)
+                for lnk in note.links
+                if lnk.target_id not in existing
+            ]
+            if not dead:
                 continue
-            for lnk in note.links:
-                if lnk.target_id not in existing:
-                    pruned.append((note.id, lnk.target_id, lnk.link_type.value))
-            note.links = live
+            note.links = [lnk for lnk in note.links if lnk.target_id in existing]
             try:
                 self.update(note)
             except Exception as e:
                 logger.error(
                     "Failed to prune dangling links from note %s: %s", note.id, e
                 )
-        return pruned
+                failed.extend(dead)
+                continue
+            pruned.extend(dead)
+        return pruned, failed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,3 +264,77 @@ def test_audit_references_fix_makes_subsequent_runs_clean():
         rerun = _run_cli("--base-dir", str(base_path), "audit-references")
         assert rerun.returncode == 0, rerun.stderr
         assert "All literature notes have references" in rerun.stdout
+
+
+def _write_note_with_link(notes_dir: Path, note_id: str, target_id: str,
+                          link_type: str = "extends") -> Path:
+    """Write a permanent note carrying a single ## Links entry to target_id."""
+    path = _write_note(notes_dir, note_id, "permanent")
+    body = path.read_text()
+    body += f"\n## Links\n\n- {link_type} [[{target_id}]]\n"
+    path.write_text(body)
+    return path
+
+
+def test_prune_links_clean_corpus_exits_zero():
+    """No dangling links: the gate must pass (exit 0)."""
+    with tempfile.TemporaryDirectory() as base:
+        base_path = Path(base)
+        notes_dir = base_path / "data" / "notes"
+        notes_dir.mkdir(parents=True)
+        target = "20260101T000000000000101"
+        _write_note(notes_dir, target, "permanent")
+        _write_note_with_link(notes_dir, "20260101T000000000000102", target)
+
+        result = _run_cli("--base-dir", str(base_path), "prune-links")
+        assert result.returncode == 0, result.stderr
+        assert "No dangling links found." in result.stdout
+
+
+def test_prune_links_dry_run_lists_and_exits_nonzero():
+    """Dangling link present: dry-run lists it, exits 1, and does NOT mutate."""
+    with tempfile.TemporaryDirectory() as base:
+        base_path = Path(base)
+        notes_dir = base_path / "data" / "notes"
+        notes_dir.mkdir(parents=True)
+        missing = "20260101T000000000000199"
+        referrer = _write_note_with_link(
+            notes_dir, "20260101T000000000000103", missing
+        )
+        before = referrer.read_text()
+
+        result = _run_cli("--base-dir", str(base_path), "prune-links")
+        assert result.returncode == 1, result.stderr
+        assert missing in result.stdout
+        # Dry run must not rewrite the referrer.
+        assert referrer.read_text() == before, "dry run mutated a note"
+
+
+def test_prune_links_fix_removes_and_exits_zero():
+    """--fix removes the dangling link from disk and exits 0."""
+    with tempfile.TemporaryDirectory() as base:
+        base_path = Path(base)
+        notes_dir = base_path / "data" / "notes"
+        notes_dir.mkdir(parents=True)
+        missing = "20260101T000000000000199"
+        referrer = _write_note_with_link(
+            notes_dir, "20260101T000000000000104", missing
+        )
+
+        result = _run_cli("--base-dir", str(base_path), "prune-links", "--fix")
+        assert result.returncode == 0, result.stderr
+        assert "Pruned 1 dangling link(s)" in result.stdout
+        assert f"[[{missing}]]" not in referrer.read_text()
+
+
+def test_prune_links_fix_clean_corpus_exits_zero():
+    """--fix with nothing to do is a clean no-op (exit 0)."""
+    with tempfile.TemporaryDirectory() as base:
+        base_path = Path(base)
+        notes_dir = base_path / "data" / "notes"
+        notes_dir.mkdir(parents=True)
+        _write_note(notes_dir, "20260101T000000000000105", "permanent")
+
+        result = _run_cli("--base-dir", str(base_path), "prune-links", "--fix")
+        assert result.returncode == 0, result.stderr
+        assert "No dangling links found." in result.stdout

--- a/tests/test_delete_referrer_sweep.py
+++ b/tests/test_delete_referrer_sweep.py
@@ -1,0 +1,95 @@
+"""Tests that deleting a note sweeps inbound references from referrers.
+
+Regression coverage for the bug where delete() removed a note's own file and
+DB row but left `[[id]]` wikilinks in the ## Links section of notes that
+pointed at it. Because the filesystem is the source of truth and
+rebuild_index re-parses ## Links from every file, those orphaned links were
+resurrected into the DB on the next rebuild.
+"""
+from slipbox_mcp.models.schema import LinkType
+
+
+class TestDeleteSweepsReferrers:
+    """delete() must rewrite notes that link TO the deleted note."""
+
+    def test_referrer_file_loses_dead_link(self, note_repository, zettel_service):
+        """After deleting target, the referrer's markdown drops the [[target]] line."""
+        target = zettel_service.create_note(
+            title="Target Note",
+            content="The note that will be deleted.",
+        )
+        referrer = zettel_service.create_note(
+            title="Referrer Note",
+            content="Points at the target.",
+        )
+        zettel_service.create_link(
+            source_id=referrer.id,
+            target_id=target.id,
+            link_type=LinkType.EXTENDS,
+            description="depends on target",
+            bidirectional=True,
+        )
+
+        referrer_path = note_repository.notes_dir / f"{referrer.id}.md"
+        assert f"[[{target.id}]]" in referrer_path.read_text()
+
+        note_repository.delete(target.id)
+
+        body = referrer_path.read_text()
+        assert f"[[{target.id}]]" not in body, (
+            "Referrer markdown still contains a link to the deleted note"
+        )
+
+    def test_rebuild_index_does_not_resurrect_link(self, note_repository, zettel_service):
+        """The killer assertion: a rebuild must not bring the dead link back.
+
+        This is what the demo exposed. Even if delete() cleaned the DB, the
+        link lived on in the referrer's file and rebuild_index re-parsed it.
+        """
+        target = zettel_service.create_note(
+            title="Target Note",
+            content="Will be deleted.",
+        )
+        referrer = zettel_service.create_note(
+            title="Referrer Note",
+            content="Points at the target.",
+        )
+        zettel_service.create_link(
+            source_id=referrer.id,
+            target_id=target.id,
+            link_type=LinkType.EXTENDS,
+            bidirectional=True,
+        )
+
+        note_repository.delete(target.id)
+        note_repository.rebuild_index()
+
+        # No link in the DB should reference the deleted note as a target.
+        from sqlalchemy import select
+        from slipbox_mcp.models.db_models import DBLink
+        with note_repository.session_factory() as session:
+            dead = session.scalars(
+                select(DBLink).where(DBLink.target_id == target.id)
+            ).all()
+        assert not dead, (
+            f"rebuild_index resurrected {len(dead)} link(s) to the deleted note"
+        )
+
+    def test_live_links_survive_delete(self, note_repository, zettel_service):
+        """Deleting one target must not strip the referrer's OTHER links."""
+        target = zettel_service.create_note(title="Doomed", content="Goes away.")
+        survivor = zettel_service.create_note(title="Survivor", content="Stays.")
+        referrer = zettel_service.create_note(title="Referrer", content="Links to both.")
+
+        zettel_service.create_link(
+            source_id=referrer.id, target_id=target.id, link_type=LinkType.EXTENDS
+        )
+        zettel_service.create_link(
+            source_id=referrer.id, target_id=survivor.id, link_type=LinkType.REFERENCE
+        )
+
+        note_repository.delete(target.id)
+
+        body = (note_repository.notes_dir / f"{referrer.id}.md").read_text()
+        assert f"[[{target.id}]]" not in body
+        assert f"[[{survivor.id}]]" in body, "Deleting one target wrongly removed an unrelated link"

--- a/tests/test_delete_referrer_sweep.py
+++ b/tests/test_delete_referrer_sweep.py
@@ -6,7 +6,10 @@ pointed at it. Because the filesystem is the source of truth and
 rebuild_index re-parses ## Links from every file, those orphaned links were
 resurrected into the DB on the next rebuild.
 """
+import pytest
+
 from slipbox_mcp.models.schema import LinkType
+from slipbox_mcp.storage.note_repository import ReferrerSweepError
 
 
 class TestDeleteSweepsReferrers:
@@ -93,3 +96,67 @@ class TestDeleteSweepsReferrers:
         body = (note_repository.notes_dir / f"{referrer.id}.md").read_text()
         assert f"[[{target.id}]]" not in body
         assert f"[[{survivor.id}]]" in body, "Deleting one target wrongly removed an unrelated link"
+
+    def test_sweeps_all_referrers(self, note_repository, zettel_service):
+        """The sweep is a loop; every referrer must lose the dead link.
+
+        A single-referrer test cannot catch a sweep that only handles the
+        first (or last) referrer, so exercise iteration explicitly.
+        """
+        target = zettel_service.create_note(title="Hub", content="Linked from many.")
+        referrers = [
+            zettel_service.create_note(title=f"Ref {i}", content="points")
+            for i in range(3)
+        ]
+        for referrer in referrers:
+            zettel_service.create_link(
+                source_id=referrer.id, target_id=target.id, link_type=LinkType.EXTENDS
+            )
+
+        note_repository.delete(target.id)
+        note_repository.rebuild_index()
+
+        for referrer in referrers:
+            body = (note_repository.notes_dir / f"{referrer.id}.md").read_text()
+            assert f"[[{target.id}]]" not in body, (
+                f"Referrer {referrer.id} kept the dead link after sweep"
+            )
+
+    def test_sweep_failure_is_surfaced_not_swallowed(
+        self, note_repository, zettel_service, monkeypatch
+    ):
+        """If a referrer's rewrite fails, delete() must raise, not report success.
+
+        Regression guard for the swallow-and-continue path: a failed sweep
+        left a dangling [[id]] that rebuild_index would resurrect, while the
+        caller saw a clean delete. delete() now raises ReferrerSweepError, and
+        the OTHER referrers are still swept (one failure does not abort the rest).
+        """
+        target = zettel_service.create_note(title="Hub", content="Linked from many.")
+        bad = zettel_service.create_note(title="Bad Referrer", content="rewrite fails")
+        good = zettel_service.create_note(title="Good Referrer", content="rewrite ok")
+        for referrer in (bad, good):
+            zettel_service.create_link(
+                source_id=referrer.id, target_id=target.id, link_type=LinkType.EXTENDS
+            )
+
+        real_update = note_repository.update
+
+        def flaky_update(note):
+            if note.id == bad.id:
+                raise IOError("disk full")
+            return real_update(note)
+
+        monkeypatch.setattr(note_repository, "update", flaky_update)
+
+        with pytest.raises(ReferrerSweepError) as excinfo:
+            note_repository.delete(target.id)
+
+        # The error names the deleted note and the un-swept referrer.
+        assert target.id in str(excinfo.value)
+        assert bad.id in str(excinfo.value)
+        assert excinfo.value.failures == [(bad.id, "disk full")]
+
+        # The healthy referrer was still swept despite the other's failure.
+        good_body = (note_repository.notes_dir / f"{good.id}.md").read_text()
+        assert f"[[{target.id}]]" not in good_body

--- a/tests/test_prune_dangling_links.py
+++ b/tests/test_prune_dangling_links.py
@@ -46,8 +46,9 @@ class TestFindDanglingLinks:
 class TestPruneDanglingLinks:
     def test_removes_stub_from_file(self, note_repository, zettel_service):
         referrer_id, target_id = _orphan_a_link(note_repository, zettel_service)
-        pruned = note_repository.prune_dangling_links()
+        pruned, failed = note_repository.prune_dangling_links()
         assert (referrer_id, target_id, "extends") in pruned
+        assert failed == []
         body = (note_repository.notes_dir / f"{referrer_id}.md").read_text()
         assert f"[[{target_id}]]" not in body
 
@@ -80,3 +81,64 @@ class TestPruneDanglingLinks:
         body = (note_repository.notes_dir / f"{referrer.id}.md").read_text()
         assert f"[[{target.id}]]" not in body
         assert f"[[{survivor.id}]]" in body
+
+    def test_failed_update_reported_as_failed_not_pruned(
+        self, note_repository, zettel_service, monkeypatch
+    ):
+        """A note whose rewrite throws must land in `failed`, never `pruned`.
+
+        Regression guard: the original code appended to `pruned` before the
+        write, so a failed update() was reported as a successful prune. The
+        return value must never claim a prune that did not happen.
+        """
+        referrer_id, target_id = _orphan_a_link(note_repository, zettel_service)
+
+        def boom(note):
+            raise IOError("disk full")
+
+        monkeypatch.setattr(note_repository, "update", boom)
+        pruned, failed = note_repository.prune_dangling_links()
+
+        assert (referrer_id, target_id, "extends") not in pruned
+        assert (referrer_id, target_id, "extends") in failed
+        # The stub is still on disk because the rewrite failed.
+        body = (note_repository.notes_dir / f"{referrer_id}.md").read_text()
+        assert f"[[{target_id}]]" in body
+
+    def test_reports_multiple_dead_links_in_one_note(
+        self, note_repository, zettel_service
+    ):
+        """One note linking to two deleted targets prunes both."""
+        dead_a = zettel_service.create_note(title="Dead A", content="x")
+        dead_b = zettel_service.create_note(title="Dead B", content="y")
+        referrer = zettel_service.create_note(title="Ref", content="z")
+        zettel_service.create_link(
+            source_id=referrer.id, target_id=dead_a.id, link_type=LinkType.EXTENDS
+        )
+        zettel_service.create_link(
+            source_id=referrer.id, target_id=dead_b.id, link_type=LinkType.REFERENCE
+        )
+        (note_repository.notes_dir / f"{dead_a.id}.md").unlink()
+        (note_repository.notes_dir / f"{dead_b.id}.md").unlink()
+        note_repository.rebuild_index()
+
+        pruned, failed = note_repository.prune_dangling_links()
+        assert failed == []
+        assert (referrer.id, dead_a.id, "extends") in pruned
+        assert (referrer.id, dead_b.id, "reference") in pruned
+        body = (note_repository.notes_dir / f"{referrer.id}.md").read_text()
+        assert f"[[{dead_a.id}]]" not in body
+        assert f"[[{dead_b.id}]]" not in body
+
+    def test_reports_actual_link_type(self, note_repository, zettel_service):
+        """The reported link_type reflects the real link, not a hardcoded value."""
+        target = zettel_service.create_note(title="Target", content="x")
+        referrer = zettel_service.create_note(title="Ref", content="y")
+        zettel_service.create_link(
+            source_id=referrer.id, target_id=target.id, link_type=LinkType.CONTRADICTS
+        )
+        (note_repository.notes_dir / f"{target.id}.md").unlink()
+        note_repository.rebuild_index()
+
+        dangling = note_repository.find_dangling_links()
+        assert (referrer.id, target.id, "contradicts") in dangling

--- a/tests/test_prune_dangling_links.py
+++ b/tests/test_prune_dangling_links.py
@@ -1,0 +1,82 @@
+"""Tests for dangling-link detection and pruning.
+
+Covers the corpus-cleanup path: stubs left in ## Links sections by deletes
+that predate referrer-sweeping, or by hand-editing. find_dangling_links is
+read-only; prune_dangling_links rewrites affected notes.
+"""
+from slipbox_mcp.models.schema import LinkType
+
+
+def _orphan_a_link(note_repository, zettel_service):
+    """Create referrer->target link, then delete target's FILE only to
+    simulate a pre-existing dangling stub (bypassing the new sweep)."""
+    target = zettel_service.create_note(title="Target", content="goes away")
+    referrer = zettel_service.create_note(title="Referrer", content="points")
+    zettel_service.create_link(
+        source_id=referrer.id,
+        target_id=target.id,
+        link_type=LinkType.EXTENDS,
+    )
+    # Remove the target file directly, leaving the stub in referrer's body.
+    (note_repository.notes_dir / f"{target.id}.md").unlink()
+    note_repository.rebuild_index()
+    return referrer.id, target.id
+
+
+class TestFindDanglingLinks:
+    def test_detects_stub(self, note_repository, zettel_service):
+        referrer_id, target_id = _orphan_a_link(note_repository, zettel_service)
+        dangling = note_repository.find_dangling_links()
+        assert (referrer_id, target_id, "extends") in dangling
+
+    def test_clean_corpus_returns_empty(self, note_repository, zettel_service):
+        a = zettel_service.create_note(title="A", content="a")
+        b = zettel_service.create_note(title="B", content="b")
+        zettel_service.create_link(source_id=a.id, target_id=b.id)
+        assert note_repository.find_dangling_links() == []
+
+    def test_find_is_read_only(self, note_repository, zettel_service):
+        referrer_id, _ = _orphan_a_link(note_repository, zettel_service)
+        before = (note_repository.notes_dir / f"{referrer_id}.md").read_text()
+        note_repository.find_dangling_links()
+        after = (note_repository.notes_dir / f"{referrer_id}.md").read_text()
+        assert before == after, "find_dangling_links mutated a note"
+
+
+class TestPruneDanglingLinks:
+    def test_removes_stub_from_file(self, note_repository, zettel_service):
+        referrer_id, target_id = _orphan_a_link(note_repository, zettel_service)
+        pruned = note_repository.prune_dangling_links()
+        assert (referrer_id, target_id, "extends") in pruned
+        body = (note_repository.notes_dir / f"{referrer_id}.md").read_text()
+        assert f"[[{target_id}]]" not in body
+
+    def test_survives_rebuild(self, note_repository, zettel_service):
+        referrer_id, target_id = _orphan_a_link(note_repository, zettel_service)
+        note_repository.prune_dangling_links()
+        note_repository.rebuild_index()
+        from sqlalchemy import select
+        from slipbox_mcp.models.db_models import DBLink
+        with note_repository.session_factory() as session:
+            dead = session.scalars(
+                select(DBLink).where(DBLink.target_id == target_id)
+            ).all()
+        assert not dead
+
+    def test_preserves_live_links(self, note_repository, zettel_service):
+        target = zettel_service.create_note(title="Doomed", content="x")
+        survivor = zettel_service.create_note(title="Survivor", content="y")
+        referrer = zettel_service.create_note(title="Ref", content="z")
+        zettel_service.create_link(
+            source_id=referrer.id, target_id=target.id, link_type=LinkType.EXTENDS
+        )
+        zettel_service.create_link(
+            source_id=referrer.id, target_id=survivor.id, link_type=LinkType.REFERENCE
+        )
+        (note_repository.notes_dir / f"{target.id}.md").unlink()
+        note_repository.rebuild_index()
+
+        note_repository.prune_dangling_links()
+        body = (note_repository.notes_dir / f"{referrer.id}.md").read_text()
+        assert f"[[{target.id}]]" not in body
+        assert f"[[{survivor.id}]]" in body


### PR DESCRIPTION
## Problem

Deleting a note removed its file and its own DB rows, but left every **inbound** `[[id]]` reference untouched in the referrers' markdown. Because the filesystem is the source of truth, the next `rebuild_index` would resurrect those dead links back into the DB — so a "deleted" note kept haunting the graph as dangling edges.

## Fix

`NoteRepository.delete()` now sweeps inbound references as part of the delete:

- Collect referrers via `find_linked_notes(id, direction="incoming")` **before** deletion, while the DB index still knows who points at the note.
- After the note's own file/DB rows are removed, re-read each referrer from disk and rewrite it through `update()` with the dead link dropped, regenerating its `## Links` block.
- Sweeping a referrer is best-effort: a failure on one referrer is logged, not fatal, so the primary delete still succeeds.

## Cleanup tooling

Adds a `prune-links` CLI command for graphs that already accumulated dangling links from pre-fix deletes or hand-editing:

- `slipbox prune-links` — read-only; lists every `source --type--> target (missing)` and exits non-zero (usable as a CI gate).
- `slipbox prune-links --fix` — rewrites affected notes to drop the dead links.

Backed by two read/write repository helpers, `find_dangling_links()` and `prune_dangling_links()`.

## Tests

- `test_delete_referrer_sweep.py` — deleting a note strips inbound links from referrers and they survive a rebuild.
- `test_prune_dangling_links.py` — dangling links are detected and pruned.

9 new tests, all green.

Also includes a `conftest.py` sys.path pin (so the worktree's local `src/` wins over any site-installed copy) and a `scripts/new-worktree.sh` helper for per-worktree venvs.
