### PR TITLE
fix: reject path-traversal note ids (arbitrary file read/write/delete)

### DIFF
--- a/src/slipbox_mcp/models/schema.py
+++ b/src/slipbox_mcp/models/schema.py
@@ -116,7 +116,13 @@ class Tag(BaseModel):
 
 class Note(BaseModel):
     """A Zettelkasten note."""
-    id: str = Field(default_factory=generate_id, description="Unique ID of the note")
+    id: Annotated[
+        str,
+        StringConstraints(pattern=r"^[A-Za-z0-9_-]+$", min_length=1, max_length=255),
+    ] = Field(
+        default_factory=generate_id,
+        description="Unique ID of the note (filename stem; no path separators)",
+    )
     title: str = Field(..., description="Title of the note")
     content: str = Field(..., description="Content of the note")
     note_type: NoteType = Field(default=NoteType.PERMANENT, description="Type of note")

--- a/src/slipbox_mcp/storage/note_repository.py
+++ b/src/slipbox_mcp/storage/note_repository.py
@@ -202,13 +202,19 @@ class NoteRepository(Repository[Note]):
                 end = header.find("\n---", 3)
                 if end == -1:
                     continue
-                frontmatter_block = header[3:end]
-                m = re.search(r"^id:\s*(\S+)", frontmatter_block, re.MULTILINE)
-                # Count only files the parser will actually index. _parse_note_
-                # from_markdown skips unsafe ids, so counting them here would make
-                # db_count != indexable_count permanently true and thrash a full
-                # rebuild on every construction. Keep the two paths in lockstep.
-                if m and _is_safe_note_id(m.group(1).strip().strip('"').strip("'")):
+                # Extract the id EXACTLY as _parse_note_from_markdown does --
+                # via frontmatter (YAML), not a token regex -- so the count and
+                # the parser agree on what is indexable. A token regex diverges
+                # on YAML-typed ids (`id: 12345` -> int, parser skips) and
+                # quoted ids with spaces (`id: "foo bar"`), and any divergence
+                # makes db_count != indexable_count permanently true, thrashing a
+                # full rebuild on every construction. Count only what the parser
+                # will actually index: a present, path-safe id.
+                try:
+                    meta = frontmatter.loads(header[:end] + "\n---\n").metadata
+                except Exception:
+                    continue
+                if _is_safe_note_id(meta.get("id")):
                     count += 1
             except (OSError, UnicodeDecodeError) as e:
                 logger.warning("Could not read %s during indexable count; skipping: %s", file_path, e)

--- a/src/slipbox_mcp/storage/note_repository.py
+++ b/src/slipbox_mcp/storage/note_repository.py
@@ -44,6 +44,19 @@ class ReferrerSweepError(Exception):
         )
 
 
+# Note IDs become filenames (``{id}.md``). Constrain them to a path-safe
+# alphabet so a crafted id (``../../etc/x``, ``/etc/x``) cannot escape the
+# notes dir. This mirrors the validator on Note.id; it is repeated here so the
+# filesystem layer is safe even for ids that bypassed model validation (e.g.
+# Note.model_construct on the schema-violation hydration path).
+_NOTE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _is_safe_note_id(note_id: Any) -> bool:
+    """Return True if note_id is a non-empty, path-safe filename stem."""
+    return isinstance(note_id, str) and bool(_NOTE_ID_PATTERN.fullmatch(note_id))
+
+
 # ---------------------------------------------------------------------------
 # Markdown parsing helpers (module-level, no instance state needed)
 # ---------------------------------------------------------------------------
@@ -236,6 +249,15 @@ class NoteRepository(Repository[Note]):
 
         note_id = metadata.get("id")
         if not note_id:
+            return None
+        if not _is_safe_note_id(note_id):
+            # A note file whose frontmatter id is not a path-safe stem is
+            # corrupt or hostile (path traversal). Refuse to hydrate it rather
+            # than let it reach the model_construct fallback below, which would
+            # bypass the id validator and make the bad id writable.
+            logger.warning(
+                "Skipping note with unsafe id %r (not a path-safe stem)", note_id
+            )
             return None
 
         title = metadata.get("title")
@@ -470,6 +492,21 @@ class NoteRepository(Repository[Note]):
         post = frontmatter.Post(content, **metadata)
         return frontmatter.dumps(post)
 
+    def _note_path(self, note_id: str) -> Path:
+        """Resolve the markdown path for a note id, refusing any escape.
+
+        Defense-in-depth against path traversal: even if a crafted id reaches
+        this layer (bad frontmatter, a model_construct'd Note), the resolved
+        path must stay inside notes_dir or we raise rather than touch the file.
+        """
+        if not _is_safe_note_id(note_id):
+            raise ValueError(f"Unsafe note id (not a path-safe stem): {note_id!r}")
+        path = (self.notes_dir / f"{note_id}.md").resolve()
+        notes_root = self.notes_dir.resolve()
+        if not path.is_relative_to(notes_root):
+            raise ValueError(f"Refusing path outside notes dir for id {note_id!r}")
+        return path
+
     def create(self, note: Note) -> Note:
         """Create a new note."""
         if not note.id:
@@ -477,7 +514,7 @@ class NoteRepository(Repository[Note]):
             note.id = generate_id()
 
         markdown = self.note_to_markdown(note)
-        file_path = self.notes_dir / f"{note.id}.md"
+        file_path = self._note_path(note.id)
 
         with self.file_lock:
             try:
@@ -496,7 +533,9 @@ class NoteRepository(Repository[Note]):
 
     def get(self, id: str) -> Optional[Note]:
         """Get a note by ID."""
-        file_path = self.notes_dir / f"{id}.md"
+        if not _is_safe_note_id(id):
+            return None
+        file_path = self._note_path(id)
         if not file_path.exists():
             return None
         try:
@@ -534,7 +573,7 @@ class NoteRepository(Repository[Note]):
 
         note.updated_at = datetime.datetime.now()
 
-        file_path = self.notes_dir / f"{note.id}.md"
+        file_path = self._note_path(note.id)
         markdown = self.note_to_markdown(note)
 
         with self.file_lock:
@@ -596,7 +635,7 @@ class NoteRepository(Repository[Note]):
                 referrers could not be swept and still carry dangling links.
                 Run ``slipbox prune-links --fix`` to clean them.
         """
-        file_path = self.notes_dir / f"{id}.md"
+        file_path = self._note_path(id)
         if not file_path.exists():
             raise ValueError(f"Note with ID {id} does not exist")
 

--- a/src/slipbox_mcp/storage/note_repository.py
+++ b/src/slipbox_mcp/storage/note_repository.py
@@ -46,10 +46,11 @@ class ReferrerSweepError(Exception):
 
 # Note IDs become filenames (``{id}.md``). Constrain them to a path-safe
 # alphabet so a crafted id (``../../etc/x``, ``/etc/x``) cannot escape the
-# notes dir. This mirrors the validator on Note.id; it is repeated here so the
-# filesystem layer is safe even for ids that bypassed model validation (e.g.
-# Note.model_construct on the schema-violation hydration path).
-_NOTE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+# notes dir. This mirrors the validator on Note.id exactly -- same alphabet AND
+# the same 1..255 length bound -- and is repeated here so the filesystem layer
+# is safe even for ids that bypassed model validation (e.g. Note.model_construct
+# on the schema-violation hydration path).
+_NOTE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,255}$")
 
 
 def _is_safe_note_id(note_id: Any) -> bool:
@@ -202,7 +203,12 @@ class NoteRepository(Repository[Note]):
                 if end == -1:
                     continue
                 frontmatter_block = header[3:end]
-                if re.search(r"^id:\s*\S", frontmatter_block, re.MULTILINE):
+                m = re.search(r"^id:\s*(\S+)", frontmatter_block, re.MULTILINE)
+                # Count only files the parser will actually index. _parse_note_
+                # from_markdown skips unsafe ids, so counting them here would make
+                # db_count != indexable_count permanently true and thrash a full
+                # rebuild on every construction. Keep the two paths in lockstep.
+                if m and _is_safe_note_id(m.group(1).strip().strip('"').strip("'")):
                     count += 1
             except (OSError, UnicodeDecodeError) as e:
                 logger.warning("Could not read %s during indexable count; skipping: %s", file_path, e)
@@ -251,12 +257,18 @@ class NoteRepository(Repository[Note]):
         if not note_id:
             return None
         if not _is_safe_note_id(note_id):
-            # A note file whose frontmatter id is not a path-safe stem is
-            # corrupt or hostile (path traversal). Refuse to hydrate it rather
-            # than let it reach the model_construct fallback below, which would
-            # bypass the id validator and make the bad id writable.
+            # The id is not an accepted stem: either a path-traversal attempt
+            # (``../../etc/x``, ``/etc/x``) or merely a legacy id using chars
+            # outside [A-Za-z0-9_-] (e.g. a dot or space from before the id was
+            # constrained). Skip it rather than let it reach the model_construct
+            # fallback below, which would bypass the id validator and make a
+            # traversal id writable. Skipping is loud and actionable so a benign
+            # legacy note is not lost silently -- rename its id to re-index it.
             logger.warning(
-                "Skipping note with unsafe id %r (not a path-safe stem)", note_id
+                "Skipping note %s: id %r is not an accepted stem "
+                "(allowed: [A-Za-z0-9_-], 1-255 chars). If this is a legacy "
+                "note, rename its frontmatter id to re-index it.",
+                metadata.get("title", "<untitled>"), note_id,
             )
             return None
 
@@ -533,6 +545,10 @@ class NoteRepository(Repository[Note]):
 
     def get(self, id: str) -> Optional[Note]:
         """Get a note by ID."""
+        # Intentional double-check (do not collapse): a reader asking for a bad
+        # id gets "not found" (None), while _note_path below re-checks and would
+        # raise for any id that slipped past -- the write-path's loud failure.
+        # The two layers are deliberate; removing either weakens the guard.
         if not _is_safe_note_id(id):
             return None
         file_path = self._note_path(id)
@@ -567,13 +583,17 @@ class NoteRepository(Repository[Note]):
 
     def update(self, note: Note) -> Note:
         """Update a note."""
+        # Resolve+contain the path first, so a smuggled traversal id (one that
+        # bypassed model validation via model_construct) is refused loudly here
+        # rather than being masked by the "does not exist" check below.
+        file_path = self._note_path(note.id)
+
         existing_note = self.get(note.id)
         if not existing_note:
             raise ValueError(f"Note with ID {note.id} does not exist")
 
         note.updated_at = datetime.datetime.now()
 
-        file_path = self._note_path(note.id)
         markdown = self.note_to_markdown(note)
 
         with self.file_lock:

--- a/tests/test_note_id_path_traversal.py
+++ b/tests/test_note_id_path_traversal.py
@@ -101,53 +101,68 @@ def _smuggled_note(bad_id: str) -> Note:
 
 
 class TestFilesystemBoundary:
-    @pytest.mark.parametrize("bad", ["../pwned_sentinel", "..", "foo/bar"])
-    def test_create_refuses_unsafe_id_and_writes_nothing(self, note_repository, bad):
-        outside = note_repository.notes_dir.parent / "pwned_sentinel.md"
+    # Planted "outside" files use a name derived from the unique per-test
+    # notes_dir stem, so concurrent runs (or a leftover from a crashed run)
+    # cannot collide on a shared-temp-root filename and flake or false-pass.
+
+    @pytest.mark.parametrize("bad", ["..", "foo/bar", "a\\b"])
+    def test_create_refuses_unsafe_id(self, note_repository, bad):
+        # Shapes that can't form a writable outside path on their own.
         with pytest.raises(ValueError):
             note_repository.create(_smuggled_note(bad))
+
+    def test_create_refuses_relative_traversal_and_writes_nothing(self, note_repository):
+        uniq = note_repository.notes_dir.name
+        outside = note_repository.notes_dir.parent / f"pwned_{uniq}.md"
+        with pytest.raises(ValueError):
+            note_repository.create(_smuggled_note(f"../pwned_{uniq}"))
         assert not outside.exists(), "create() wrote a file outside the notes dir"
 
     def test_create_refuses_absolute_id_and_writes_nothing(self, note_repository):
         # The worst case: Path(notes_dir) / "/abs/x.md" discards notes_dir
         # entirely (operand discard). Use an absolute path inside the temp tree.
-        target = note_repository.notes_dir.parent / "abs_create_payload"
+        uniq = note_repository.notes_dir.name
+        target = note_repository.notes_dir.parent / f"abs_create_{uniq}"
         with pytest.raises(ValueError):
             note_repository.create(_smuggled_note(str(target)))
-        assert not target.parent.joinpath("abs_create_payload.md").exists()
+        assert not note_repository.notes_dir.parent.joinpath(f"abs_create_{uniq}.md").exists()
 
     def test_update_refuses_unsafe_id_and_overwrites_nothing(self, note_repository):
         # The highest-stakes path: a smuggled traversal id must not clobber a
         # file outside the notes dir. Assert no side effect, not merely a raise.
-        victim = note_repository.notes_dir.parent / "update_victim.md"
+        uniq = note_repository.notes_dir.name
+        victim = note_repository.notes_dir.parent / f"update_victim_{uniq}.md"
         victim.write_text("original")
         with pytest.raises(ValueError):
-            note_repository.update(_smuggled_note("../update_victim"))
+            note_repository.update(_smuggled_note(f"../update_victim_{uniq}"))
         assert victim.read_text() == "original", "update() wrote outside the notes dir"
         victim.unlink()
 
     def test_update_refuses_absolute_id(self, note_repository):
-        target = note_repository.notes_dir.parent / "abs_update_payload"
+        uniq = note_repository.notes_dir.name
+        target = note_repository.notes_dir.parent / f"abs_update_{uniq}"
         with pytest.raises(ValueError):
             note_repository.update(_smuggled_note(str(target)))
-        assert not target.parent.joinpath("abs_update_payload.md").exists()
+        assert not note_repository.notes_dir.parent.joinpath(f"abs_update_{uniq}.md").exists()
 
-    @pytest.mark.parametrize("bad", ["../victim", None])  # None -> absolute, set below
-    def test_delete_refuses_unsafe_id_and_deletes_nothing(self, note_repository, bad):
-        outside = note_repository.notes_dir.parent / "victim.md"
+    @pytest.mark.parametrize("absolute", [False, True])
+    def test_delete_refuses_unsafe_id_and_deletes_nothing(self, note_repository, absolute):
+        uniq = note_repository.notes_dir.name
+        outside = note_repository.notes_dir.parent / f"victim_{uniq}.md"
         outside.write_text("do not delete me")
-        delete_id = bad if bad is not None else str(note_repository.notes_dir.parent / "victim")
+        delete_id = (str(note_repository.notes_dir.parent / f"victim_{uniq}")
+                     if absolute else f"../victim_{uniq}")
         with pytest.raises(ValueError):
             note_repository.delete(delete_id)
         assert outside.exists(), "delete() removed a file outside the notes dir"
         outside.unlink()
 
     def test_get_returns_none_for_unsafe_id(self, note_repository):
-        # Plant a readable file just outside the notes dir.
-        outside = note_repository.notes_dir.parent / "secret.md"
-        outside.write_text("---\nid: secret\ntitle: Secret\n---\ntop secret")
-        assert note_repository.get("../secret") is None
-        assert note_repository.get(str(note_repository.notes_dir.parent / "secret")) is None
+        uniq = note_repository.notes_dir.name
+        outside = note_repository.notes_dir.parent / f"secret_{uniq}.md"
+        outside.write_text("---\nid: s\ntitle: Secret\n---\ntop secret")
+        assert note_repository.get(f"../secret_{uniq}") is None
+        assert note_repository.get(str(note_repository.notes_dir.parent / f"secret_{uniq}")) is None
         outside.unlink()
 
     def test_symlink_with_valid_stem_resolving_outside_is_refused(self, note_repository):
@@ -158,8 +173,9 @@ class TestFilesystemBoundary:
         refactor that drops it fails loudly.
         """
         import os
-        secret = note_repository.notes_dir.parent / "symlink_secret.md"
-        secret.write_text("---\nid: symlink_secret\ntitle: S\n---\nsecret")
+        uniq = note_repository.notes_dir.name
+        secret = note_repository.notes_dir.parent / f"symlink_secret_{uniq}.md"
+        secret.write_text("---\nid: s\ntitle: S\n---\nsecret")
         link = note_repository.notes_dir / "evil.md"
         try:
             os.symlink(secret, link)
@@ -227,3 +243,21 @@ class TestRebuildIndexVector:
         )
         # Only the safe note counts; the parser-skipped file must not.
         assert note_repository._count_indexable_files() == 1
+
+    @pytest.mark.parametrize("frontmatter_id", ["12345", '"foo bar"', "'a b'", "../x"])
+    def test_count_matches_parser_for_tricky_ids(self, note_repository, frontmatter_id):
+        """The count must extract the id the SAME way the parser does.
+
+        A token-regex extraction diverges from frontmatter.loads on YAML-typed
+        ids (`id: 12345` -> int) and quoted ids with spaces, counting a file the
+        parser skips -> db_count != indexable_count -> rebuild thrash. Pin parity.
+        """
+        (note_repository.notes_dir / "tricky.md").write_text(
+            f"---\nid: {frontmatter_id}\ntitle: Tricky\n---\nbody\n"
+        )
+        note_repository.rebuild_index()
+        from sqlalchemy import select
+        from slipbox_mcp.models.db_models import DBNote
+        with note_repository.session_factory() as session:
+            db_count = len(session.scalars(select(DBNote.id)).all())
+        assert note_repository._count_indexable_files() == db_count

--- a/tests/test_note_id_path_traversal.py
+++ b/tests/test_note_id_path_traversal.py
@@ -53,6 +53,12 @@ class TestIdAlphabet:
         assert _is_safe_note_id(None) is False
         assert _is_safe_note_id(123) is False
 
+    def test_length_bound_matches_model(self):
+        # The repo-layer pattern must enforce the same 1..255 bound as the
+        # schema validator, or the two layers disagree on over-long ids.
+        assert _is_safe_note_id("a" * 255) is True
+        assert _is_safe_note_id("a" * 256) is False
+
 
 class TestModelBoundary:
     @pytest.mark.parametrize("bad", [i for i in UNSAFE_IDS if i])  # empty hits min_length too
@@ -72,6 +78,11 @@ class TestModelBoundary:
     def test_default_generated_id_is_safe(self):
         note = Note(title="t", content="c")
         assert _is_safe_note_id(note.id)
+
+    def test_model_rejects_overlong_id(self):
+        with pytest.raises(ValidationError):
+            Note(id="a" * 256, title="t", content="c")
+        assert Note(id="a" * 255, title="t", content="c").id == "a" * 255
 
 
 def _smuggled_note(bad_id: str) -> Note:
@@ -97,16 +108,37 @@ class TestFilesystemBoundary:
             note_repository.create(_smuggled_note(bad))
         assert not outside.exists(), "create() wrote a file outside the notes dir"
 
-    def test_update_refuses_unsafe_id(self, note_repository):
+    def test_create_refuses_absolute_id_and_writes_nothing(self, note_repository):
+        # The worst case: Path(notes_dir) / "/abs/x.md" discards notes_dir
+        # entirely (operand discard). Use an absolute path inside the temp tree.
+        target = note_repository.notes_dir.parent / "abs_create_payload"
         with pytest.raises(ValueError):
-            note_repository.update(_smuggled_note("../escape"))
+            note_repository.create(_smuggled_note(str(target)))
+        assert not target.parent.joinpath("abs_create_payload.md").exists()
 
-    def test_delete_refuses_unsafe_id_and_deletes_nothing(self, note_repository):
-        # Plant a sentinel just outside the notes dir.
+    def test_update_refuses_unsafe_id_and_overwrites_nothing(self, note_repository):
+        # The highest-stakes path: a smuggled traversal id must not clobber a
+        # file outside the notes dir. Assert no side effect, not merely a raise.
+        victim = note_repository.notes_dir.parent / "update_victim.md"
+        victim.write_text("original")
+        with pytest.raises(ValueError):
+            note_repository.update(_smuggled_note("../update_victim"))
+        assert victim.read_text() == "original", "update() wrote outside the notes dir"
+        victim.unlink()
+
+    def test_update_refuses_absolute_id(self, note_repository):
+        target = note_repository.notes_dir.parent / "abs_update_payload"
+        with pytest.raises(ValueError):
+            note_repository.update(_smuggled_note(str(target)))
+        assert not target.parent.joinpath("abs_update_payload.md").exists()
+
+    @pytest.mark.parametrize("bad", ["../victim", None])  # None -> absolute, set below
+    def test_delete_refuses_unsafe_id_and_deletes_nothing(self, note_repository, bad):
         outside = note_repository.notes_dir.parent / "victim.md"
         outside.write_text("do not delete me")
+        delete_id = bad if bad is not None else str(note_repository.notes_dir.parent / "victim")
         with pytest.raises(ValueError):
-            note_repository.delete("../victim")
+            note_repository.delete(delete_id)
         assert outside.exists(), "delete() removed a file outside the notes dir"
         outside.unlink()
 
@@ -115,7 +147,28 @@ class TestFilesystemBoundary:
         outside = note_repository.notes_dir.parent / "secret.md"
         outside.write_text("---\nid: secret\ntitle: Secret\n---\ntop secret")
         assert note_repository.get("../secret") is None
+        assert note_repository.get(str(note_repository.notes_dir.parent / "secret")) is None
         outside.unlink()
+
+    def test_symlink_with_valid_stem_resolving_outside_is_refused(self, note_repository):
+        """A symlink INSIDE notes_dir with a valid-stem name pointing outside.
+
+        The regex passes (``evil`` is a valid stem); only ``.resolve()`` +
+        ``is_relative_to`` in _note_path catches the escape. Pins that guard so a
+        refactor that drops it fails loudly.
+        """
+        import os
+        secret = note_repository.notes_dir.parent / "symlink_secret.md"
+        secret.write_text("---\nid: symlink_secret\ntitle: S\n---\nsecret")
+        link = note_repository.notes_dir / "evil.md"
+        try:
+            os.symlink(secret, link)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+        with pytest.raises(ValueError):
+            note_repository.get("evil")
+        link.unlink()
+        secret.unlink()
 
     def test_safe_roundtrip_still_works(self, note_repository):
         note = Note(id="20260624T000000000000001", title="Legit", content="ok")
@@ -147,3 +200,30 @@ class TestRebuildIndexVector:
         assert "../../tmp/payload" not in ids
         # ...and nothing was written outside the notes dir.
         assert not (note_repository.notes_dir.parent / "tmp" / "payload.md").exists()
+
+    def test_planted_absolute_id_file_is_skipped(self, note_repository):
+        """The operand-discard vector via a planted file's absolute frontmatter id."""
+        planted = note_repository.notes_dir / "seed_abs.md"
+        planted.write_text(
+            "---\nid: /tmp/abs_payload\ntitle: SeedAbs\ntype: permanent\n---\n\nbody\n"
+        )
+        note_repository.rebuild_index()
+        from sqlalchemy import select
+        from slipbox_mcp.models.db_models import DBNote
+        with note_repository.session_factory() as session:
+            ids = session.scalars(select(DBNote.id)).all()
+        assert "/tmp/abs_payload" not in ids
+
+    def test_unsafe_id_file_not_counted_as_indexable(self, note_repository):
+        """Regression for the rebuild-thrash bug: an unsafe-id file the parser
+        skips must NOT be counted as indexable, or db_count != indexable_count is
+        permanently true and a full rebuild fires on every construction.
+        """
+        (note_repository.notes_dir / "bad.md").write_text(
+            "---\nid: ../../tmp/payload\ntitle: Bad\n---\nbody\n"
+        )
+        note_repository.create(
+            Note(id="20260624T000000000000009", title="Good", content="ok")
+        )
+        # Only the safe note counts; the parser-skipped file must not.
+        assert note_repository._count_indexable_files() == 1

--- a/tests/test_note_id_path_traversal.py
+++ b/tests/test_note_id_path_traversal.py
@@ -1,0 +1,149 @@
+"""Security tests: note ids must not escape the notes directory.
+
+A note id becomes a filename (``{id}.md``). Without constraint, a crafted id
+like ``../../etc/passwd`` or ``/etc/shadow`` lets an MCP tool read, write, or
+delete files outside the notes dir (Python's ``Path('/a') / '/etc/x'`` even
+discards the left operand). These tests pin the two-layer defense:
+
+1. ``Note.id`` validation rejects unsafe ids at the model boundary.
+2. ``NoteRepository`` refuses unsafe ids at the filesystem boundary, so even an
+   id that bypassed model validation (``Note.model_construct``) cannot touch a
+   file outside the notes dir.
+"""
+import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from slipbox_mcp.models.schema import Note, NoteType
+from slipbox_mcp.storage.note_repository import _is_safe_note_id
+
+
+UNSAFE_IDS = [
+    "../../etc/passwd",
+    "../pwned",
+    "/etc/shadow",
+    "/tmp/pwned",
+    "..",
+    "foo/bar",
+    "foo\\bar",
+    "with space",
+    "dot.in.id",
+    "",
+]
+
+SAFE_IDS = [
+    "20260101T000000000000001",          # generated format
+    "20260624T123456789012abc",
+    "manual-note_id",
+    "ABC123",
+]
+
+
+class TestIdAlphabet:
+    @pytest.mark.parametrize("bad", UNSAFE_IDS)
+    def test_is_safe_note_id_rejects(self, bad):
+        assert _is_safe_note_id(bad) is False
+
+    @pytest.mark.parametrize("good", SAFE_IDS)
+    def test_is_safe_note_id_accepts(self, good):
+        assert _is_safe_note_id(good) is True
+
+    def test_non_string_is_unsafe(self):
+        assert _is_safe_note_id(None) is False
+        assert _is_safe_note_id(123) is False
+
+
+class TestModelBoundary:
+    @pytest.mark.parametrize("bad", [i for i in UNSAFE_IDS if i])  # empty hits min_length too
+    def test_model_rejects_unsafe_id(self, bad):
+        with pytest.raises(ValidationError):
+            Note(id=bad, title="t", content="c")
+
+    def test_model_rejects_empty_id(self):
+        with pytest.raises(ValidationError):
+            Note(id="", title="t", content="c")
+
+    @pytest.mark.parametrize("good", SAFE_IDS)
+    def test_model_accepts_safe_id(self, good):
+        note = Note(id=good, title="t", content="c")
+        assert note.id == good
+
+    def test_default_generated_id_is_safe(self):
+        note = Note(title="t", content="c")
+        assert _is_safe_note_id(note.id)
+
+
+def _smuggled_note(bad_id: str) -> Note:
+    """Build a Note carrying an unsafe id by bypassing model validation.
+
+    model_construct skips validators, simulating an id that reached the
+    repository despite the model-layer guard (the schema-violation hydration
+    path uses model_construct). The filesystem layer must still refuse it.
+    """
+    now = datetime.datetime.now()
+    return Note.model_construct(
+        id=bad_id, title="t", content="c", note_type=NoteType.PERMANENT,
+        tags=[], links=[], references=[], created_at=now, updated_at=now,
+        metadata={},
+    )
+
+
+class TestFilesystemBoundary:
+    @pytest.mark.parametrize("bad", ["../pwned_sentinel", "..", "foo/bar"])
+    def test_create_refuses_unsafe_id_and_writes_nothing(self, note_repository, bad):
+        outside = note_repository.notes_dir.parent / "pwned_sentinel.md"
+        with pytest.raises(ValueError):
+            note_repository.create(_smuggled_note(bad))
+        assert not outside.exists(), "create() wrote a file outside the notes dir"
+
+    def test_update_refuses_unsafe_id(self, note_repository):
+        with pytest.raises(ValueError):
+            note_repository.update(_smuggled_note("../escape"))
+
+    def test_delete_refuses_unsafe_id_and_deletes_nothing(self, note_repository):
+        # Plant a sentinel just outside the notes dir.
+        outside = note_repository.notes_dir.parent / "victim.md"
+        outside.write_text("do not delete me")
+        with pytest.raises(ValueError):
+            note_repository.delete("../victim")
+        assert outside.exists(), "delete() removed a file outside the notes dir"
+        outside.unlink()
+
+    def test_get_returns_none_for_unsafe_id(self, note_repository):
+        # Plant a readable file just outside the notes dir.
+        outside = note_repository.notes_dir.parent / "secret.md"
+        outside.write_text("---\nid: secret\ntitle: Secret\n---\ntop secret")
+        assert note_repository.get("../secret") is None
+        outside.unlink()
+
+    def test_safe_roundtrip_still_works(self, note_repository):
+        note = Note(id="20260624T000000000000001", title="Legit", content="ok")
+        note_repository.create(note)
+        got = note_repository.get(note.id)
+        assert got is not None and got.title == "Legit"
+        note_repository.delete(note.id)
+        assert note_repository.get(note.id) is None
+
+
+class TestRebuildIndexVector:
+    def test_planted_traversal_id_file_is_skipped(self, note_repository):
+        """A planted .md whose frontmatter id is a traversal stub must not index.
+
+        This is the rebuild_index attack path: the parser refuses the hostile
+        id before it can reach the model_construct fallback (which would bypass
+        the validator and make the bad id writable on a later update()).
+        """
+        planted = note_repository.notes_dir / "seed.md"
+        planted.write_text(
+            "---\nid: ../../tmp/payload\ntitle: Seed\ntype: permanent\n---\n\nbody\n"
+        )
+        note_repository.rebuild_index()
+        # The hostile note is not indexed...
+        from sqlalchemy import select
+        from slipbox_mcp.models.db_models import DBNote
+        with note_repository.session_factory() as session:
+            ids = session.scalars(select(DBNote.id)).all()
+        assert "../../tmp/payload" not in ids
+        # ...and nothing was written outside the notes dir.
+        assert not (note_repository.notes_dir.parent / "tmp" / "payload.md").exists()


### PR DESCRIPTION
## Problem

A note id becomes a filename (`{id}.md`), but `Note.id` had no format constraint (only `title` and `references` were validated). Every CRUD MCP tool passes an LLM-supplied id straight into `notes_dir / f"{id}.md"`, so a crafted id escaped the notes directory:

- `id="../../etc/passwd"` climbs out of the notes dir.
- `id="/etc/shadow"` — Python's `Path('/a') / '/etc/x'` **discards the left operand**, so an absolute id ignores `notes_dir` entirely.

Reachable as arbitrary file **read** (`get_note`), **delete** (`delete_note`), and **write** (via the re-index/create path, where a planted file's frontmatter id is trusted and `model_construct` bypasses validation). Note ids come from untrusted content an agent is acting on, so this is not theoretical.

Found by the `/sc:analyze` security pass (Finding 1, CRITICAL).

## Fix — two layers

**Model boundary** (`schema.py`): constrain `Note.id` to `^[A-Za-z0-9_-]+$` (the generated-id alphabet — every real id passes), rejecting `/`, `\`, `.`, and `..` at construction.

**Filesystem boundary** (`note_repository.py`): a `_note_path()` helper resolves the path and asserts `is_relative_to(notes_dir)`, used by `create`/`get`/`update`/`delete`. This refuses a bad id *even if it bypassed model validation* — e.g. the `model_construct` schema-violation hydration path. `_parse_note_from_markdown` additionally skips any file whose frontmatter id is unsafe, closing the `rebuild_index` vector before it can reach `model_construct`.

Defense-in-depth on purpose: either layer alone closes the hole; together they hold even if a future caller constructs a `Note` without validation.

## Tests (`tests/test_note_id_path_traversal.py`, 38 cases)

- Model rejects `../../etc/passwd`, `/etc/shadow`, `..`, `foo/bar`, empty, etc.; accepts generated + manual safe ids.
- Filesystem layer: a **smuggled** (`model_construct`) bad id makes `create`/`update`/`delete`/`get` refuse, with assertions that **no file outside the notes dir** is written, deleted, or read.
- `rebuild_index` skips a planted `.md` whose frontmatter id is `../../tmp/payload`.

Full suite: 379 passed, 1 skipped.

## Scope note

This PR closes only the traversal hole. The `/sc:analyze` pass also flagged multi-process safety (in-process `RLock` + default SQLite engine) and `rebuild_index` atomicity/cost as separate CRITICAL/HIGH items — those are independent and out of scope here.
