### PR TITLE
feat: generate standalone skills from MCP prompt templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,8 @@ jobs:
       - run: uv venv --python 3.13 && uv pip install -e ".[dev]" ruff
       - run: uv run ruff check src/ evals/
       - run: uv run pytest -q
+      - name: Skills are regenerated from the prompt templates (no drift)
+        run: |
+          uv run python scripts/build_skills.py
+          git diff --exit-code skills/ \
+            || { echo "::error::skills/ is out of date. Run 'python scripts/build_skills.py' and commit."; exit 1; }

--- a/README.md
+++ b/README.md
@@ -350,21 +350,25 @@ MCP prompts are reusable workflow templates that encode the Zettelkasten method 
 
 ### How to Invoke: Slash Commands and Skills
 
-Each workflow ships two ways, both generated from one source (`src/slipbox_mcp/server/descriptions.py`) so they can't drift:
+Each workflow ships two ways:
 
 - **MCP prompts** — served by the running server.
 - **Skills** — standalone bundles (`skills/<name>/`) that run the same workflow and add natural-language triggering.
 
-**Slash commands** are the reliable path. In Claude Code, type `/slipbox-mcp:` for the prompt picker:
+Five of the six skills are generated from the same `PROMPT_*` templates the server uses (`src/slipbox_mcp/server/descriptions.py`), and CI fails if the committed `skills/` drift from those templates. The sixth, `cluster-maintenance`, is authored directly in `scripts/build_skills.py` because its MCP prompt is a runtime-rendered status message rather than a reusable workflow.
+
+**Slash commands** are the reliable path. Claude Code surfaces MCP prompts as `/mcp__<server>__<prompt>`; type `/mcp__slipbox-mcp__` for the picker:
 
 ```text
-/slipbox-mcp:knowledge_creation
-/slipbox-mcp:knowledge_exploration
-/slipbox-mcp:knowledge_synthesis
-/slipbox-mcp:knowledge_creation_batch
-/slipbox-mcp:analyze_note
-/slipbox-mcp:cluster_maintenance
+/mcp__slipbox-mcp__knowledge_creation
+/mcp__slipbox-mcp__knowledge_exploration
+/mcp__slipbox-mcp__knowledge_synthesis
+/mcp__slipbox-mcp__knowledge_creation_batch
+/mcp__slipbox-mcp__analyze_note
+/mcp__slipbox-mcp__cluster_maintenance
 ```
+
+(Installed skills also expose their own slash commands by directory name, e.g. `/slipbox-analyze-note`.)
 
 **Natural language** works once the matching skill is installed — just describe what you want:
 
@@ -380,7 +384,13 @@ Prose triggering depends on the skill being installed and your phrasing matching
 
 ### Installing Skills
 
-**Claude Code** discovers the `skills/<name>/SKILL.md` directories from the repo — nothing to install.
+**Claude Code** discovers skills from `.claude/skills/` (per project) or `~/.claude/skills/` (global), not from a bare top-level `skills/`. Symlink or copy the ones you want into a discovery path — e.g. for this project:
+
+```bash
+mkdir -p .claude/skills
+ln -s ../../skills/slipbox-analyze-note .claude/skills/slipbox-analyze-note
+# ...or copy the directories, or symlink all six
+```
 
 **Claude Desktop** needs each skill as a `.skill` bundle. Build them, then upload:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Built and tested with Claude. Works with any MCP client (Claude Desktop, Claude 
 **Plain files, zero lock-in.** Notes are markdown with YAML frontmatter -- readable in Obsidian, Foam, Logseq, or any editor. The SQLite database is an index, not the source of truth. Delete it and rebuild from files anytime.
 
 - **19 MCP tools** for notes, links, search, graph analysis, and cluster management
-- **6 workflow prompts** encoding the Zettelkasten method so you don't re-explain it every session
+- **6 workflow prompts** (plus matching skills) encoding the Zettelkasten method so you don't re-explain it every session
 - **BM25 full-text search** across titles and content via SQLite FTS5
 - **Cluster detection** finds emergent topic groups and scaffolds structure notes
 - **Seven typed links** (reference, extends, refines, contradicts, questions, supports, related)
@@ -348,30 +348,49 @@ MCP prompts are reusable workflow templates that encode the Zettelkasten method 
 | `analyze_note` | Evaluate a note's fitness for the slipbox | Reviewing a new or existing note |
 | `cluster_maintenance` | Surface pending housekeeping | Start of a working session |
 
-### How to Use Prompts
+### How to Invoke: Slash Commands and Skills
 
-MCP clients that support prompts (like Claude Code) expose them as slash commands:
+Each workflow ships two ways, both generated from one source (`src/slipbox_mcp/server/descriptions.py`) so they can't drift:
 
-```text
-/mcp__slipbox-mcp__knowledge_creation
-/mcp__slipbox-mcp__knowledge_exploration
-/mcp__slipbox-mcp__knowledge_synthesis
-/mcp__slipbox-mcp__knowledge_creation_batch
-/mcp__slipbox-mcp__analyze_note
-/mcp__slipbox-mcp__cluster_maintenance
-```
+- **MCP prompts** — served by the running server.
+- **Skills** — standalone bundles (`skills/<name>/`) that run the same workflow and add natural-language triggering.
 
-For clients without a prompt picker UI, invoke prompts conversationally:
+**Slash commands** are the reliable path. In Claude Code, type `/slipbox-mcp:` for the prompt picker:
 
 ```text
-Use the knowledge_creation prompt with this content: [paste text]
-
-Use the knowledge_exploration prompt for the topic: "poetry and cognitive load"
-
-Use the cluster_maintenance prompt.
+/slipbox-mcp:knowledge_creation
+/slipbox-mcp:knowledge_exploration
+/slipbox-mcp:knowledge_synthesis
+/slipbox-mcp:knowledge_creation_batch
+/slipbox-mcp:analyze_note
+/slipbox-mcp:cluster_maintenance
 ```
 
-The agent calls the prompt template behind the scenes and fills in your input.
+**Natural language** works once the matching skill is installed — just describe what you want:
+
+```text
+Analyze this note for my slipbox: [paste note]
+
+Add this to my slipbox: [paste article]
+
+Synthesize my notes on attention and memory.
+```
+
+Prose triggering depends on the skill being installed and your phrasing matching its description; fall back to the slash command if it doesn't fire. Asking the model to "use the analyze_note prompt" by name does **not** work — the model can't invoke an MCP prompt by name. Use a slash command, or let a skill trigger from natural language.
+
+### Installing Skills
+
+**Claude Code** discovers the `skills/<name>/SKILL.md` directories from the repo — nothing to install.
+
+**Claude Desktop** needs each skill as a `.skill` bundle. Build them, then upload:
+
+```bash
+python scripts/build_skills.py     # writes dist/*.skill
+```
+
+Go to Settings → Skills → Upload skill and select the bundles from `dist/` you want. Each installs as both a slash command and a natural-language trigger.
+
+After editing a prompt template in `descriptions.py`, re-run the build to regenerate the skills.
 
 ---
 

--- a/demo-script.md
+++ b/demo-script.md
@@ -1,7 +1,7 @@
 # slipbox-mcp Demo Recording Script
 
 **Target length:** ~12 minutes
-**Setup:** Three windows ready to switch between — Claude (CLI or Desktop), Obsidian open to the vault, terminal in the slipbox-mcp repo.
+**Setup:** Three windows ready to switch between: Claude (CLI or Desktop), Obsidian open to the vault, terminal in the slipbox-mcp repo.
 **Recording note:** All Claude responses below are pre-captured in `demo.md`. You don't need to wait for fresh responses on camera — talk over them while they stream, or pre-record the streams and narrate.
 
 ---
@@ -24,6 +24,7 @@ If the top cluster has 15+ notes (e.g. "Engineering Philosophy"), the structure-
 **Environment:**
 
 - [ ] Claude session started, MCP server connected (verify with one quick prompt off-camera)
+- [ ] Slipbox skills installed in Claude Desktop — run `python scripts/build_skills.py`, then Settings → Skills → Upload skill and add the `dist/*.skill` bundles (§7 needs `slipbox-analyze-note.skill`; §9 shows the full set)
 - [ ] Obsidian open to the slipbox vault
 - [ ] Obsidian graph view ready (Cmd+G) and a "good" note open in another tab — pick one with rich backlinks (`Contract Testing Knowledge Map` is currently the most connected at 52 links)
 - [ ] Terminal in `~/Workspace/personal/slipbox-mcp` with a clean prompt
@@ -36,7 +37,7 @@ If the top cluster has 15+ notes (e.g. "Engineering Philosophy"), the structure-
 
 | SCREEN | What you say | What you do |
 |---|---|---|
-| **Terminal** | "This is slipbox-mcp. It's a Model Context Protocol server that turns Claude into an active participant in a Zettelkasten knowledge system — not just a note-taker, but something that finds connections, surfaces patterns, and proposes structure." | Run `SLIPBOX_BASE_DIR=. slipbox status` so the audience sees the real numbers (currently ~553 notes, ~1585 tags, 7 pending clusters — but confirm with the pre-flight). |
+| **Terminal** | "Want to show you slipbox-mcp. A Model Context Protocol server that turns Claude into a working partner in a Zettelkasten. Not just a note-taker; something that finds connections and proposes structure." | Run `SLIPBOX_BASE_DIR=. slipbox status` so the audience sees the real numbers (currently ~554 notes, ~1585 tags, 5 pending clusters — but confirm with the pre-flight). |
 | **Terminal** | "Everything you'll see runs against my real notes. More than 550 of them, accumulated over months of daily use. No mocks, no fake data." | Leave the status output on screen for a beat, then transition. |
 
 ---
@@ -56,8 +57,8 @@ If the top cluster has 15+ notes (e.g. "Engineering Philosophy"), the structure-
 | SCREEN | What you say | What you do |
 |---|---|---|
 | **Claude** | "Here's the first thing I want Claude doing every session — telling me what needs attention" | Paste the prompt: `Use the slipbox://maintenance-status resource and tell me if there's anything that needs attention.` |
-| **Claude** | "What it's reading is an MCP resource — a live endpoint the server exposes. In a well-configured Claude Desktop setup, this can fire automatically when the session starts. Claude becomes a proactive knowledge manager, not a passive assistant." | Let the response stream. Highlight the cluster table when it lands. |
-| **Claude** | "Seven pending clusters. Three or four above the urgency threshold. Notice it's not just listing them — it's explaining *why* the top one ranks first: more orphaned notes, lower internal link density, so a structure note there gives me the most connectivity gain per minute spent." | Point at the top cluster row and the orphan count. (Adapt the talk to whichever cluster is actually #1 on the day — Engineering Philosophy or Prompt Engineering at the time of writing.) |
+| **Claude** | "What it's reading is an MCP resource: a live endpoint the server exposes, not a tool it's calling. It audits the whole vault and ranks what needs attention. This is the first prompt I run every session." | Let the response stream. Highlight the cluster table when it lands. |
+| **Claude** | "Five pending clusters, ranked by urgency. The top one is the highest-leverage thing I could do in this vault right now. At the end I'll come back and actually do it. One question, and it surfaces structural work I'd never spot browsing note by note." | Point at the top cluster row. (Adapt the talk to whichever cluster is actually #1 on the day — Prompt Engineering Knowledge Map at the time of writing.) |
 
 ---
 
@@ -65,8 +66,8 @@ If the top cluster has 15+ notes (e.g. "Engineering Philosophy"), the structure-
 
 | SCREEN | What you say | What you do |
 |---|---|---|
-| **Claude** | "Now the simplest possible thing — search. But not grep. This is BM25-ranked full-text search across every note, in milliseconds." | Paste: `Search my notes for "zettelkasten workflow" and show me the most relevant results.` |
-| **Claude** | "The ranking is what matters. The top result is a note about slipbox-mcp itself — meta. The next two are about workflow patterns. Below that, related-but-less-central. This is the FTS5 index doing the work." | Point at the score ordering as the table renders. |
+| **Claude** | "Hold that thought on the clusters — at the end I'll turn one into a structure note. First, the primitives underneath it. Simplest one: search. Not grep. BM25-ranked full-text search across every note, in milliseconds." | Paste: `Search my notes for "zettelkasten workflow" and show me the most relevant results.` |
+| **Claude** | "Top result is a note about slipbox-mcp itself: meta. Next two are workflow patterns. Below that, related but less central. That's the FTS5 index ranking by relevance, not keyword match." | Point at the score ordering as the table renders. |
 
 ---
 
@@ -75,13 +76,13 @@ If the top cluster has 15+ notes (e.g. "Engineering Philosophy"), the structure-
 | SCREEN | What you say | What you do |
 |---|---|---|
 | **Claude** | "Two questions that only make sense if your notes are a graph: which ones are central, and which ones are isolated?" | Paste: `Which notes are the most connected in my Zettelkasten? Show me the top 10.` |
-| **Claude** | "Top of the list: Contract Testing Knowledge Map, with 52 connections. That's a structure note — a hub. Below it, you can see what I actually think about: contract testing, software craft, poetry, consciousness. The graph reveals my preoccupations." | Let the table render. Briefly run a finger down the list. |
+| **Claude** | "Top of the list: Contract Testing Knowledge Map, with 52 connections. That's a structure note: a hub. Below it, you can see what I actually think about: contract testing, software craft, poetry, consciousness. The graph reveals my preoccupations." | Let the table render. Briefly run a finger down the list. |
 | **Obsidian** | "Let me show you what 'central' actually looks like." | Switch to Obsidian. Open the global graph view (Cmd+G). |
-| **Obsidian** | "Five hundred and fifty-three nodes. The bright clusters are the hubs — those are the structure notes from Claude's list. The thin tendrils between them are typed links. The empty space at the edges? That's where the orphans live." | Let the graph spin / zoom out so the topology is visible. |
+| **Obsidian** | "Five hundred and fifty-four nodes. The bright clusters are the hubs: those are the structure notes from Claude's list. The thin tendrils between them are typed links. The empty space at the edges? That's where the orphans live." | Let the graph spin / zoom out so the topology is visible. |
 | **Obsidian** | "Here's the local graph for Contract Testing Knowledge Map." | Open the central note, switch to local graph. |
 | **Obsidian** | "You can see how a structure note works — it's a small constellation. The structure note is the center, member notes orbit it, and each member note has its own connections branching outward." | Hover over a couple of edges to show the typed relationships. |
 | **Claude** | "Now the inverse — what's *not* connected." | Switch back to Claude. Paste: `Find all my orphaned notes — the ones with no connections to anything else.` |
-| **Claude** | "Sixty-two orphans. That's 11% of the vault. These are notes I captured but never integrated. They're not bad — they're debt. And the system makes them visible so I can pay it down." | Let the response render. |
+| **Claude** | "Fifty-eight orphans. That's about 10% of the vault. These are notes I captured but never integrated. They're not bad. They're debt. And the system makes them visible so I can pay it down." | Let the response render. |
 
 ---
 
@@ -94,8 +95,8 @@ I've been thinking about something. Here's my rough idea:
 
 "When I read technical books, I tend to extract too many notes at once.
 I end up with 30 fleeting notes from a single chapter and never process them.
-The bottleneck isn't capture — it's integration. Maybe I should limit myself
-to 3-5 notes per reading session and immediately link each one before moving on."
+Getting them down is easy; connecting them is where I stall. Maybe I should
+limit myself to 3-5 notes per reading session and link each one before moving on."
 
 Capture this as a permanent note and find related notes to link it to.
 ```
@@ -103,9 +104,9 @@ Capture this as a permanent note and find related notes to link it to.
 | SCREEN | What you say | What you do |
 |---|---|---|
 | **Claude** | "Here's the workflow I use most. I have a rough thought. I want it in the slipbox, properly formed, properly linked. I don't want to do the formatting work myself." | Paste the prompt above. |
-| **Claude** | "The important thing here: Claude doesn't generate the idea. The idea is mine. Claude formats it into an atomic note, infers tags from my existing taxonomy — not new ones — and links it to related notes that already exist." | Let the response stream. |
-| **Claude** | "Look at the link types. *Extends* — building in the same direction. *Refines* — tightening a previous claim. Those aren't decorative. They encode argumentative structure. Future-me can traverse this graph by argument, not just by topic." | Point at the link-types table when it renders. |
-| **Claude** | "This is the core value proposition. Claude is a *formatting and integration layer*. The thinking stays mine." | Brief pause, let the audience absorb. |
+| **Claude** | "Claude doesn't generate the idea. The idea is mine. It formats that into an atomic note, infers tags, preferring my existing taxonomy where they fit, and links it to related notes that already exist." | Let the response stream. |
+| **Claude** | "Look at the link types. *Extends*: building in the same direction. *Refines*: tightening a previous claim. They encode argumentative structure. Future-me can traverse this graph by argument, not just by topic." | Point at the link-types table when it renders. |
+| **Claude** | "Claude is a *formatting and integration layer*. The thinking stays mine." | Brief pause. |
 
 ---
 
@@ -114,59 +115,50 @@ Capture this as a permanent note and find related notes to link it to.
 **Prompt to paste:**
 
 ```text
-Use the analyze_note prompt with this note:
+Analyze this note for my slipbox:
 
 "Luhmann's slip-box worked because the constraints forced understanding.
 You can't write an atomic note without decomposing what you read. You
 can't link it without understanding how it relates to what you already know.
 The method is a thinking tool disguised as a filing system. But most digital
-implementations miss this — they optimize for capture speed instead of
-integration depth. The real bottleneck was never writing notes down."
+implementations miss this — they optimize for capture speed when the hard
+part was always integration."
 ```
 
 | SCREEN | What you say | What you do |
 |---|---|---|
-| **Claude** | "Capture is one half. The other half is checking what you just captured against the rest of your knowledge. That's the analyze prompt." | Paste the prompt above. |
-| **Claude** | "Five dimensions. Atomicity — is this one idea or four? Connectivity — what does it link to in *my actual graph*, not in the abstract? Tag suggestions from the existing taxonomy. A clarity rewrite. And emergent insights." | Let the response stream. Pause at the atomicity table. |
-| **Claude** | "Notice it can spot near-duplicates of notes I already have — and tell me that *before* I add a new one, so I can decide whether to merge, split, or skip. This is the difference between a search index and a thinking partner." | Scroll to whatever the connectivity / near-duplicate callout is in the live response. |
+| **Claude** | "Capture is one half. The other half is checking what you just captured against the rest of your knowledge. That's the analyze workflow." | Paste the prompt above. |
+| **Claude** | "Five dimensions. Atomicity — is this one idea or four? Connectivity — what does it link to in *my actual graph*, not in the abstract? Tag suggestions, preferring my existing taxonomy. A clarity rewrite. And emergent insights." | Let the response stream. Pause at the atomicity table. |
+| **Claude** | "It spots near-duplicates of notes I already have — and tells me *before* I add a new one, so I can merge, split, or skip. That's the difference between a search index and a thinking partner." | Scroll to whatever the connectivity / near-duplicate callout is in the live response. |
 
 ---
 
 ## 8. The big one: cluster → structure note (~90s)
 
-**Prompt to paste** (use option A or B based on what's currently top — see pre-flight):
-
-A. *If the top cluster has ~7 notes (a clean fit on screen):*
+**Prompt to paste:**
 
 ```text
 Take the highest-scoring cluster and create a structure note for it.
 Link it to all the member notes.
 ```
 
-B. *If the top cluster has 15+ notes (e.g. Engineering Philosophy) and you want a tighter visual:*
-
-```text
-Look at the cluster report, take the cluster called "Prompt Engineering Knowledge Map",
-and create a structure note for it. Link it to all the member notes.
-```
-
 | SCREEN | What you say | What you do |
 |---|---|---|
-| **Claude** | "Remember the maintenance status from the start — seven pending clusters? Let's close the loop. I'm going to take one of those clusters and have Claude turn it into a structure note." | Paste prompt A or B. |
-| **Claude** | "What's happening: Claude is creating the structure note, writing a synthesis stub, creating bidirectional `reference` links to every member note, and dismissing the cluster from future maintenance reports. One prompt, full scaffolding." | Let the response complete. |
+| **Claude** | "Remember the maintenance status from the start — five pending clusters, ranked? Let's close the loop. This one ranked first because it had the most orphaned notes and the loosest internal linking. So a structure note here buys the most connectivity per minute spent. I'm going to take it and have Claude build that note." | Paste the prompt. |
+| **Claude** | "Claude creates the structure note, writes a synthesis stub, builds bidirectional `reference` links to every member note, and dismisses the cluster from future maintenance reports. One prompt, full scaffolding." | Let the response complete. |
 | **Obsidian** | "And here's the result in Obsidian." | Switch to Obsidian. Open the new structure note (search by title or paste the ID Claude returned). |
 | **Obsidian** | "Fresh backlinks. Open the local graph and you can see the new constellation that didn't exist 30 seconds ago." | Cmd+G or local graph view on the new note. |
-| **Claude** | "Next time I run the maintenance check, this cluster won't appear. It's been promoted from emergent to organized. That's the loop — emergent → organized → forgotten about — repeated as the vault grows." | Brief pause for the punchline. |
+| **Claude** | "Next time I run the maintenance check, this cluster won't appear. It's been promoted from emergent to organized. That's the loop: emergent → organized → forgotten about, repeated as the vault grows." | Brief pause for the punchline. |
 
 ---
 
-## 9. The prompts library (~60s)
+## 9. The skills library (~60s)
 
 | SCREEN | What you say | What you do |
 |---|---|---|
-| **Claude** | "Everything I just showed you is a prompt away. The MCP server exposes them as slash commands." | Type `/mcp__slipbox-mcp__` to trigger autocomplete and let the list show. |
+| **Claude** | "Everything I just showed you is one command away. Each workflow is installed as a skill — so it's a slash command, or I can trigger it in plain language like I did with analyze." | Type `/` to bring up the installed slipbox skills and let the list show. |
 | **Claude** | "Knowledge creation, knowledge exploration, knowledge synthesis, batch creation for book chapters, analyze-note, cluster maintenance. Each one is a structured workflow that encodes the Zettelkasten method so I don't re-explain it every session." | Let viewers see the list. Don't run one — just show they exist. |
-| **Claude** | "The synthesis prompt is the one I use least often and value most. It looks for connections I haven't drawn yet — bridges between clusters that developed independently. That's where the actual *thinking* leverage is." | Optional: briefly mention without running. |
+| **Claude** | "The synthesis workflow is the one I use least often and value most. It looks for connections I haven't drawn yet: bridges between clusters that developed independently. That's where the real thinking work gets done." | Optional: briefly mention without running. |
 
 ---
 
@@ -175,7 +167,7 @@ and create a structure note for it. Link it to all the member notes.
 | SCREEN | What you say | What you do |
 |---|---|---|
 | **Terminal** | "One last thing. Everything you saw — the search, the graph, the clusters — comes from a SQLite index. But the source of truth is the markdown files." | Run `ls -lh data/db/` to show `zettelkasten.db` (~5 MB) exists. |
-| **Terminal** | "I can blow this index away and rebuild it from the markdown files in seconds. The notes are never locked into this tool. They're plain text. They'll outlive any software I'm using to view them." | Run `SLIPBOX_BASE_DIR=. slipbox rebuild` — completes in a couple of seconds against 553 notes. (Don't actually `rm` the DB on camera; the rebuild rewrites it in place, which makes the same point without the suspense.) |
+| **Terminal** | "I can blow this index away and rebuild it from the markdown files in seconds. The notes are never locked into this tool. They're plain text. They'll outlive any software I'm using to view them." | Run `SLIPBOX_BASE_DIR=. slipbox rebuild` — completes in a couple of seconds against 554 notes. (Don't actually `rm` the DB on camera; the rebuild rewrites it in place, which makes the same point without the suspense.) |
 
 ---
 
@@ -183,11 +175,11 @@ and create a structure note for it. Link it to all the member notes.
 
 | SCREEN | What you say | What you do |
 |---|---|---|
-| **Claude or Obsidian** | "That's slipbox-mcp. Atomic notes, typed links, an active agent that processes my content rather than generating it, and zero lock-in. Repo's linked below. Build something with it." | Hold on a closing frame — the graph view is the strongest visual. |
+| **Claude or Obsidian** | "That's slipbox-mcp. Atomic notes, typed links, an active agent that processes my content rather than generating it, and zero lock-in. Repo's linked below. Build something with it." | Hold on a closing frame. The graph view is the strongest visual. |
 
 ---
 
-## Section-by-section section mapping (back to demo.md)
+## Section-by-section mapping (back to demo.md)
 
 | Recording section | demo.md section(s) | Notes |
 |---|---|---|
@@ -199,9 +191,9 @@ and create a structure note for it. Link it to all the member notes.
 | 6. Capture | §5 (line 389-431) | Highest-frequency workflow |
 | 7. Analyze | §6 (line 435-560) | The quality gate |
 | 8. Cluster→Structure | §11 (line 743-770) | Closes the loop on §3 |
-| 9. Prompts | §14 (line 872-1164) | Brief — they're aware of the surface area, that's enough |
+| 9. Skills | §14 (line 872-1164) | Brief — they're aware of the surface area, that's enough |
 | 10. Lock-in | §15 (line 1169-1183) | The trust statement |
-| 11. Close | Talking Points (line 1187-1195) | Don't recap — let the demo speak |
+| 11. Close | Talking Points (line 1187-1195) | Don't recap. Let the demo speak. |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "black>=23.0.0",
     "isort>=5.12.0",
     "mypy>=1.0.0",
+    "pyyaml>=6.0",  # used directly by scripts/build_skills.py
 ]
 
 [project.scripts]

--- a/scripts/build_skills.py
+++ b/scripts/build_skills.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Generate the slipbox skills from the MCP prompt templates.
+
+Single source of truth: the PROMPT_* templates in
+src/slipbox_mcp/server/descriptions.py — the same strings the MCP server
+serves as prompts. This script wraps each one as a standalone Claude skill so
+the two can't drift. Edit the template, re-run this; never hand-edit SKILL.md.
+
+Outputs:
+  skills/<name>/SKILL.md   browsable source + Claude Code skill discovery
+  dist/<name>.skill        zip (<name>/SKILL.md) for Claude Desktop upload
+
+Run:  python scripts/build_skills.py
+"""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+from slipbox_mcp.server.descriptions import (  # noqa: E402
+    PROMPT_ANALYZE_NOTE,
+    PROMPT_KNOWLEDGE_CREATION,
+    PROMPT_KNOWLEDGE_CREATION_BATCH,
+    PROMPT_KNOWLEDGE_EXPLORATION,
+    PROMPT_KNOWLEDGE_SYNTHESIS,
+)
+
+GENERATED_NOTICE = (
+    "<!-- Generated from src/slipbox_mcp/server/descriptions.py by "
+    "scripts/build_skills.py. Do not edit by hand. -->"
+)
+
+
+def workflow_body(template: str) -> str:
+    """Strip the trailing {content}/{topic} interpolation and its label.
+
+    The prompt templates end with the user's pasted input; a skill takes that
+    input from the conversation instead, so everything after (and the `---`
+    separator / label introducing it) is dropped.
+    """
+    body = template
+    for token in ("{content}", "{topic}"):
+        body = body.split(token, 1)[0]
+    body = body.rstrip()
+    suffixes = ("---", "Note to analyze:", "Topic/concept to explore:")
+    changed = True
+    while changed:
+        changed = False
+        for suffix in suffixes:
+            if body.endswith(suffix):
+                body = body[: -len(suffix)].rstrip()
+                changed = True
+    return body
+
+
+# Each skill: dir/command name, triggering description, and the body source.
+# Template-derived skills share their workflow with the MCP prompt verbatim.
+# cluster_maintenance's prompt is a runtime-rendered message, not a workflow,
+# so its skill body is authored here (it drives the same cluster tools).
+SKILLS = [
+    {
+        "name": "slipbox-knowledge-creation",
+        "title": "Knowledge Creation",
+        "description": (
+            "Use when adding new information to the slipbox — articles, ideas, "
+            "or notes to process into atomic Zettelkasten notes. Trigger on: add "
+            "this to my slipbox, capture this, process this into notes, make notes "
+            "from this. Grounds everything in the real slipbox via MCP tools."
+        ),
+        "body": workflow_body(PROMPT_KNOWLEDGE_CREATION),
+    },
+    {
+        "name": "slipbox-knowledge-creation-batch",
+        "title": "Knowledge Creation (Batch)",
+        "description": (
+            "Use when processing larger volumes into the slipbox — books, long "
+            "articles, or collections needing 5-10 atomic notes. Trigger on: "
+            "process this book, batch this chapter into notes, turn this long "
+            "article into notes. Grounds everything in the real slipbox via MCP tools."
+        ),
+        "body": workflow_body(PROMPT_KNOWLEDGE_CREATION_BATCH),
+    },
+    {
+        "name": "slipbox-knowledge-exploration",
+        "title": "Knowledge Exploration",
+        "description": (
+            "Use when exploring how a topic connects to existing slipbox "
+            "knowledge — discovering connections, finding hubs, identifying gaps, "
+            "mapping the graph around a concept. Trigger on: how does X connect to "
+            "my notes, what do I already know about X, map my thinking on X."
+        ),
+        "body": workflow_body(PROMPT_KNOWLEDGE_EXPLORATION),
+    },
+    {
+        "name": "slipbox-knowledge-synthesis",
+        "title": "Knowledge Synthesis",
+        "description": (
+            "Use when looking for higher-order insights across the slipbox — "
+            "bridging unconnected areas, resolving contradictions, extending "
+            "chains of thought, creating synthesis notes from emergent patterns. "
+            "Trigger on: synthesize my notes on X, find bridges between Y and Z, "
+            "what higher-order ideas connect these."
+        ),
+        "body": workflow_body(PROMPT_KNOWLEDGE_SYNTHESIS),
+    },
+    {
+        "name": "slipbox-analyze-note",
+        "title": "Analyze Note",
+        "description": (
+            "Analyze and improve a note for slipbox integration using the actual "
+            "slipbox via MCP tools. Use when the user shares a note and asks to "
+            "analyze it, improve it, integrate it, check atomicity, find "
+            "connections, suggest tags, or refine it. Trigger on: analyze this "
+            "note, check this zettel, is this atomic, what should this connect to, "
+            "suggest tags for this note. Searches before suggesting connections."
+        ),
+        "body": workflow_body(PROMPT_ANALYZE_NOTE),
+    },
+    {
+        "name": "slipbox-cluster-maintenance",
+        "title": "Cluster Maintenance",
+        "description": (
+            "Use at the start of a slipbox session to surface pending housekeeping "
+            "— knowledge clusters grown large enough to need a structure note. "
+            "Trigger on: any slipbox maintenance, what needs attention in my "
+            "slipbox, check my clusters, start-of-session housekeeping."
+        ),
+        "body": (
+            "Surface pending Zettelkasten housekeeping, grounded in the actual "
+            "slipbox.\n\n"
+            "1. Load the current cluster analysis with `slipbox_get_cluster_report`. "
+            "If it looks stale, run `slipbox_refresh_clusters` first.\n"
+            "2. Report the top clusters that lack a structure note, ranked by "
+            "urgency score (note count, orphan ratio, link density, recency).\n"
+            "3. For each, show its suggested title, note/orphan counts, score, and "
+            "ID.\n"
+            "4. Offer to: create a structure note for one "
+            "(`slipbox_create_structure_from_cluster`), show more detail, skip for "
+            "now, or dismiss permanently (`slipbox_dismiss_cluster`).\n\n"
+            "If no clusters need attention, say so — the slipbox is well-organized."
+        ),
+    },
+]
+
+
+def render(skill: dict) -> str:
+    return (
+        "---\n"
+        f"name: {skill['name']}\n"
+        f"description: \"{skill['description']}\"\n"
+        "---\n\n"
+        f"{GENERATED_NOTICE}\n\n"
+        f"# {skill['title']}\n\n"
+        f"{skill['body']}\n"
+    )
+
+
+def main() -> None:
+    skills_dir = REPO / "skills"
+    dist_dir = REPO / "dist"
+    dist_dir.mkdir(exist_ok=True)
+
+    for skill in SKILLS:
+        name = skill["name"]
+        content = render(skill)
+
+        md_path = skills_dir / name / "SKILL.md"
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.write_text(content)
+
+        bundle = dist_dir / f"{name}.skill"
+        with zipfile.ZipFile(bundle, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(f"{name}/SKILL.md", content)
+
+        print(f"  {name}: skills/{name}/SKILL.md + dist/{name}.skill")
+
+    print(f"Generated {len(SKILLS)} skills.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_skills.py
+++ b/scripts/build_skills.py
@@ -15,9 +15,13 @@ Run:  python scripts/build_skills.py
 
 from __future__ import annotations
 
+import json
+import shutil
 import sys
 import zipfile
 from pathlib import Path
+
+import yaml
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "src"))
@@ -47,14 +51,16 @@ def workflow_body(template: str) -> str:
     for token in ("{content}", "{topic}"):
         body = body.split(token, 1)[0]
     body = body.rstrip()
-    suffixes = ("---", "Note to analyze:", "Topic/concept to explore:")
-    changed = True
-    while changed:
-        changed = False
-        for suffix in suffixes:
-            if body.endswith(suffix):
-                body = body[: -len(suffix)].rstrip()
-                changed = True
+    # Strip the optional input label, then EXACTLY ONE trailing `---` separator
+    # (the scaffold that introduced the input block). Stripping one -- not the
+    # old loop over every trailing `---` -- preserves a `---` that is genuine
+    # body content (a thematic break a section legitimately ends on).
+    for label in ("Note to analyze:", "Topic/concept to explore:"):
+        if body.endswith(label):
+            body = body[: -len(label)].rstrip()
+            break
+    if body.endswith("---"):
+        body = body[: -len("---")].rstrip()
     return body
 
 
@@ -149,26 +155,53 @@ SKILLS = [
 
 
 def render(skill: dict) -> str:
-    return (
+    name, description, body = skill["name"], skill["description"], skill["body"]
+    # Fail loud rather than emit a structurally-valid-but-useless skill (an
+    # empty body, or one whose source template degraded to scaffolding).
+    if not name or not description.strip() or not body.strip():
+        raise ValueError(
+            f"Refusing to render skill {name!r}: name/description/body must all be "
+            f"non-empty (description={description!r:.40}, body_len={len(body.strip())})."
+        )
+    # json.dumps(ensure_ascii=False) is a valid YAML double-quoted scalar that
+    # escapes quotes/backslashes/newlines correctly while keeping unicode (em
+    # dashes) literal -- so a description can't silently corrupt the frontmatter.
+    content = (
         "---\n"
-        f"name: {skill['name']}\n"
-        f"description: \"{skill['description']}\"\n"
+        f"name: {name}\n"
+        f"description: {json.dumps(description, ensure_ascii=False)}\n"
         "---\n\n"
         f"{GENERATED_NOTICE}\n\n"
         f"# {skill['title']}\n\n"
-        f"{skill['body']}\n"
+        f"{body}\n"
     )
+    # Belt-and-suspenders: the rendered frontmatter must round-trip.
+    front = content.split("---\n", 2)[1]
+    parsed = yaml.safe_load(front)
+    if parsed.get("name") != name or not parsed.get("description"):
+        raise ValueError(f"Rendered frontmatter for {name!r} did not round-trip: {parsed!r}")
+    return content
 
 
 def main() -> None:
     skills_dir = REPO / "skills"
     dist_dir = REPO / "dist"
-    dist_dir.mkdir(exist_ok=True)
 
-    for skill in SKILLS:
-        name = skill["name"]
-        content = render(skill)
+    # Render + validate every skill BEFORE touching the filesystem, so a failure
+    # on one is all-or-nothing -- never a half-updated mix of new and stale.
+    rendered = {skill["name"]: render(skill) for skill in SKILLS}
+    expected = set(rendered)
 
+    # Prune stale skill dirs / bundles from a prior rename or removal.
+    if skills_dir.exists():
+        for d in skills_dir.glob("slipbox-*"):
+            if d.is_dir() and d.name not in expected:
+                shutil.rmtree(d)
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+    dist_dir.mkdir(parents=True)
+
+    for name, content in rendered.items():
         md_path = skills_dir / name / "SKILL.md"
         md_path.parent.mkdir(parents=True, exist_ok=True)
         md_path.write_text(content)
@@ -179,7 +212,7 @@ def main() -> None:
 
         print(f"  {name}: skills/{name}/SKILL.md + dist/{name}.skill")
 
-    print(f"Generated {len(SKILLS)} skills.")
+    print(f"Generated {len(rendered)} skills.")
 
 
 if __name__ == "__main__":

--- a/skills/slipbox-analyze-note/SKILL.md
+++ b/skills/slipbox-analyze-note/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: slipbox-analyze-note
+description: "Analyze and improve a note for slipbox integration using the actual slipbox via MCP tools. Use when the user shares a note and asks to analyze it, improve it, integrate it, check atomicity, find connections, suggest tags, or refine it. Trigger on: analyze this note, check this zettel, is this atomic, what should this connect to, suggest tags for this note. Searches before suggesting connections."
+---
+
+<!-- Generated from src/slipbox_mcp/server/descriptions.py by scripts/build_skills.py. Do not edit by hand. -->
+
+# Analyze Note
+
+Analyze this note for integration into my Zettelkasten. Use the slipbox tools to ground your suggestions in my actual knowledge base.
+
+## 1. Atomicity Check
+
+Does the note contain exactly one idea? If multiple concepts are present:
+- List each distinct idea that should be its own note
+- Identify the primary idea vs. supporting details
+- Search first to flag any that duplicate existing notes
+
+## 2. Connectivity Analysis
+
+**Do this before suggesting connections:**
+1. Extract 2-3 key terms from the note
+2. Run `slipbox_search_notes` for each term to find related existing notes
+3. Run `slipbox_find_similar_notes` if this is an existing note ID
+4. Check `slipbox_find_central_notes` to see if this relates to a knowledge hub
+
+**Then report:**
+- Specific existing notes this should link to (with IDs and titles)
+- Recommended link types for each connection:
+  - `extends` — builds on the target note
+  - `refines` — clarifies or improves the target
+  - `contradicts` — presents opposing view
+  - `questions` — raises doubts about the target
+  - `supports` — provides evidence for the target
+  - `related` — loose thematic connection
+
+## 3. Clarity Enhancement
+
+Rewrite the note to:
+- Express one idea clearly and completely
+- Stand alone without external context
+- Use terminology consistent with existing notes (check related notes for conventions)
+- Stay within 3-7 paragraphs
+
+Provide the rewritten version in a code block for easy copying.
+
+## 4. Metadata Suggestions
+
+**Tags:** Run `slipbox_get_all_tags` first. Suggest 3-5 tags, preferring existing tags over new ones. If proposing a new tag, justify why existing tags don't fit.
+
+**Title:** Propose a clear, searchable title that expresses the core idea.
+
+**Note type:**
+- `fleeting` — raw capture, needs processing
+- `literature` — extracted from a source. REQUIRES at least one entry in `references`. Use `fleeting` if you don't have the citation yet.
+- `permanent` — refined idea in user's own words
+- `structure` — organizes 7-15 related notes on a topic
+- `hub` — entry point to a major knowledge domain
+
+## 5. Emergent Insights
+
+Based on what you found in the slipbox:
+- Questions this note raises that aren't answered by existing notes
+- Gaps in the knowledge graph this could help fill
+- Unexpected connections to distant topics in the slipbox
+- Potential cluster this belongs to (check if related notes share tags but lack a structure note)
+
+---
+
+## Output Format
+
+```
+### Atomicity: [PASS | SPLIT NEEDED]
+[analysis]
+
+### Connections Found
+| Existing Note | Link Type | Reason |
+|---------------|-----------|--------|
+| [title] (ID)  | extends   | ...    |
+
+### Suggested Tags
+[from existing taxonomy, or justified new tags]
+
+### Proposed Title
+[title]
+
+### Note Type
+[type with rationale]
+
+### Rewritten Note
+[clean version ready for slipbox_create_note]
+
+### Emergent Insights
+[questions, gaps, unexpected connections]
+```

--- a/skills/slipbox-cluster-maintenance/SKILL.md
+++ b/skills/slipbox-cluster-maintenance/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: slipbox-cluster-maintenance
+description: "Use at the start of a slipbox session to surface pending housekeeping — knowledge clusters grown large enough to need a structure note. Trigger on: any slipbox maintenance, what needs attention in my slipbox, check my clusters, start-of-session housekeeping."
+---
+
+<!-- Generated from src/slipbox_mcp/server/descriptions.py by scripts/build_skills.py. Do not edit by hand. -->
+
+# Cluster Maintenance
+
+Surface pending Zettelkasten housekeeping, grounded in the actual slipbox.
+
+1. Load the current cluster analysis with `slipbox_get_cluster_report`. If it looks stale, run `slipbox_refresh_clusters` first.
+2. Report the top clusters that lack a structure note, ranked by urgency score (note count, orphan ratio, link density, recency).
+3. For each, show its suggested title, note/orphan counts, score, and ID.
+4. Offer to: create a structure note for one (`slipbox_create_structure_from_cluster`), show more detail, skip for now, or dismiss permanently (`slipbox_dismiss_cluster`).
+
+If no clusters need attention, say so — the slipbox is well-organized.

--- a/skills/slipbox-knowledge-creation-batch/SKILL.md
+++ b/skills/slipbox-knowledge-creation-batch/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: slipbox-knowledge-creation-batch
+description: "Use when processing larger volumes into the slipbox — books, long articles, or collections needing 5-10 atomic notes. Trigger on: process this book, batch this chapter into notes, turn this long article into notes. Grounds everything in the real slipbox via MCP tools."
+---
+
+<!-- Generated from src/slipbox_mcp/server/descriptions.py by scripts/build_skills.py. Do not edit by hand. -->
+
+# Knowledge Creation (Batch)
+
+I've attached a larger text/collection of information to process into my Zettelkasten. Please:
+
+1. First identify main themes and check my existing system for related notes and tags
+
+2. Extract 5-10 distinct atomic ideas from this material, organized into logical clusters
+   - Eliminate any concepts that duplicate my existing notes
+   - Process each validated concept into a note with appropriate type, title, tags, and content
+   - Create connections between related notes in this batch
+   - Connect each new note to relevant existing notes in my system
+
+3. Update or create structure notes as needed to integrate this batch of knowledge
+
+4. Verify quality for each note:
+   - Each note contains a single focused concept
+   - All sources are properly cited
+   - Each note has meaningful connections
+   - Terminology is consistent with my existing system
+
+Provide a summary of all notes created, connections established, and structure notes updated, along with any areas you've identified for follow-up work.

--- a/skills/slipbox-knowledge-creation/SKILL.md
+++ b/skills/slipbox-knowledge-creation/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: slipbox-knowledge-creation
+description: "Use when adding new information to the slipbox — articles, ideas, or notes to process into atomic Zettelkasten notes. Trigger on: add this to my slipbox, capture this, process this into notes, make notes from this. Grounds everything in the real slipbox via MCP tools."
+---
+
+<!-- Generated from src/slipbox_mcp/server/descriptions.py by scripts/build_skills.py. Do not edit by hand. -->
+
+# Knowledge Creation
+
+I've attached information I'd like to incorporate into my Zettelkasten. Please:
+
+First, search for existing notes that might be related before creating anything new.
+
+Then, identify 3-5 key atomic ideas from this information and for each one:
+1. Create a note with an appropriate title, type, and tags
+2. Draft content in my own words with proper attribution
+3. Find and create meaningful connections to existing notes
+4. Update any relevant structure notes
+
+After processing all ideas, provide a summary of the notes created, connections established, and any follow-up questions you have.

--- a/skills/slipbox-knowledge-exploration/SKILL.md
+++ b/skills/slipbox-knowledge-exploration/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: slipbox-knowledge-exploration
+description: "Use when exploring how a topic connects to existing slipbox knowledge — discovering connections, finding hubs, identifying gaps, mapping the graph around a concept. Trigger on: how does X connect to my notes, what do I already know about X, map my thinking on X."
+---
+
+<!-- Generated from src/slipbox_mcp/server/descriptions.py by scripts/build_skills.py. Do not edit by hand. -->
+
+# Knowledge Exploration
+
+I'd like to explore how this information connects to my existing Zettelkasten. Please:
+
+1. Identify the central concepts in this information and find related notes in my system
+
+2. Examine knowledge hubs in my Zettelkasten by:
+   - Finding central notes related to these concepts
+   - Mapping their connections and similar notes
+   - Identifying promising knowledge paths to follow
+
+3. Look for any gaps, contradictions, or orphaned notes that relate to these concepts
+
+4. Create a conceptual map showing:
+   - How this information fits with my existing knowledge
+   - Unexpected connections discovered
+   - Potential areas for development
+
+Finally, summarize what you've learned about my Zettelkasten through this exploration and highlight the most valuable insights found.

--- a/skills/slipbox-knowledge-synthesis/SKILL.md
+++ b/skills/slipbox-knowledge-synthesis/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: slipbox-knowledge-synthesis
+description: "Use when looking for higher-order insights across the slipbox — bridging unconnected areas, resolving contradictions, extending chains of thought, creating synthesis notes from emergent patterns. Trigger on: synthesize my notes on X, find bridges between Y and Z, what higher-order ideas connect these."
+---
+
+<!-- Generated from src/slipbox_mcp/server/descriptions.py by scripts/build_skills.py. Do not edit by hand. -->
+
+# Knowledge Synthesis
+
+I've attached information that might help synthesize ideas in my Zettelkasten. Please:
+
+1. Find opportunities for synthesis by identifying:
+   - Potential bridges between currently unconnected areas in my system
+   - Contradictions that this information might help resolve
+   - Incomplete chains of thought that could now be extended
+
+2. For the most promising synthesis opportunities (3-5 max):
+   - Create new permanent notes capturing the higher-order insights
+   - Connect these synthesis notes to the contributing notes with appropriate link types
+   - Update or create structure notes as needed
+
+3. Identify any relevant fleeting notes that should be converted to permanent notes in light of this synthesis
+
+4. Based on this synthesis work, highlight:
+   - New questions that have emerged
+   - Knowledge gaps revealed
+   - Potential applications of the new understanding
+
+Provide a summary of the insights discovered, notes created, and connections established through this synthesis process.

--- a/src/slipbox_mcp/server/descriptions.py
+++ b/src/slipbox_mcp/server/descriptions.py
@@ -4,6 +4,10 @@ Live source of truth for the cluster tools wired in via
 @mcp.tool(description=...) in server/tools/cluster_tools.py, and for the
 MCP prompts registered in server/prompts.py and server/mcp_server.py.
 
+The PROMPT_* templates also generate the standalone skills via
+scripts/build_skills.py (-> skills/<name>/SKILL.md and dist/*.skill).
+Re-run that build after editing a template so the skills don't drift.
+
 Note/link/search tool descriptions live as docstrings on the function
 bodies in server/tools/{note_tools,link_tools,search_tools}.py — those
 docstrings ARE the description the LLM sees, so this file deliberately


### PR DESCRIPTION
## What

Generates standalone Claude skills from the existing MCP prompt templates, so the same Zettelkasten workflows are available three ways from one source of truth.

`scripts/build_skills.py` wraps each `PROMPT_*` template in `src/slipbox_mcp/server/descriptions.py` as a skill. The templates remain the single source shared by the MCP prompts and the skills — edit a template, re-run the build; `SKILL.md` is never hand-edited (each carries a "do not edit by hand" notice).

## Outputs

- `skills/<name>/SKILL.md` — browsable in the repo, auto-discovered by Claude Code (nothing to install).
- `dist/<name>.skill` — zip bundles for Claude Desktop upload (gitignored; build artifacts).

Six skills: `knowledge_creation`, `knowledge_creation_batch`, `knowledge_exploration`, `knowledge_synthesis`, `analyze_note`, `cluster_maintenance`.

## Why skills on top of prompts

MCP prompts only fire via the `/slipbox-mcp:<name>` slash command — the model can't invoke a prompt by name from prose. Each generated skill adds a natural-language `description`, so the workflow can also trigger conversationally ("analyze this note for my slipbox"). Slash commands remain the reliable path; skills add prose triggering.

## Drift safety

The generator is deterministic: re-running `python scripts/build_skills.py` reproduces the committed `skills/` exactly, so a stale skill is a failed re-run away from being caught. `descriptions.py` documents the relationship at the top.

## Commits

1. `feat:` the generator, the six generated skills, the `descriptions.py` note, and README docs (both invocation paths + install steps).
2. `docs:` demo-script narration polish + a pre-flight step to build/upload the bundles before recording.

## Verification

`python scripts/build_skills.py` regenerates `skills/` with no diff; generated frontmatter validated (each has `name` + `description`).
