### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/src/slipbox_mcp/__init__.py
+++ b/src/slipbox_mcp/__init__.py
@@ -6,4 +6,4 @@ to form a network of knowledge.
 
 This version uses synchronous operations.
 """
-__version__ = "1.2.1"
+__version__ = "1.3.0"


### PR DESCRIPTION
Bumps `__version__` to **1.3.0** for the first PyPI release.

PR #34 added the install-UX simplification and PyPI publishing pipeline (a `feat`), so this debuts on PyPI as a minor bump from the inherited 1.2.x line.

After merge, tagging `v1.3.0` on the merge commit fires the release workflow (verify tag == `__version__` -> build -> `twine check` -> publish via Trusted Publishing).

Single source of truth: `pyproject.toml` reads this dynamically and `config.server_version` derives from it; `tests/test_version.py` confirms the wiring.
