### PR TITLE
chore: remove dead code and fix broken worktree doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,20 +16,31 @@ Run the test suite to verify your setup:
 uv run pytest tests/
 ```
 
+### Inspecting the server
+
+To poke at the MCP server interactively (tools, prompts, resources) with the
+MCP Inspector:
+
+```bash
+mcp dev src/slipbox_mcp/dev.py
+```
+
+`dev.py` just exposes the server object the Inspector looks for.
+
 ### Working in a git worktree
 
 This package is installed editable, so each worktree needs its own venv;
 otherwise it imports the main checkout's source and you test the wrong code.
-Use the helper, which creates the worktree under `.worktrees/` and syncs it:
+Create the worktree under `.worktrees/` and sync a dedicated venv inside it:
 
 ```bash
-scripts/new-worktree.sh fix/my-change            # branches from origin/main
-scripts/new-worktree.sh fix/my-change my-base    # or from another ref
+git worktree add .worktrees/fix-my-change -b fix/my-change origin/main
+cd .worktrees/fix-my-change
+uv venv --python 3.13 && uv sync --all-extras
 ```
 
-Then `cd` into the printed path and run `uv run pytest`. (A `conftest.py`
-path shim guards the case where the venv hasn't been synced, but a per-worktree
-venv is the real fix.)
+Then run `uv run pytest` from that path. (A `conftest.py` path shim guards the
+case where the venv hasn't been synced, but a per-worktree venv is the real fix.)
 
 ## Project Structure
 

--- a/src/slipbox_mcp/formatting.py
+++ b/src/slipbox_mcp/formatting.py
@@ -20,32 +20,6 @@ def format_tag_list(tags) -> str:
     return ", ".join(names)
 
 
-def format_note_summary(
-    note: Note,
-    index: int = 0,
-    preview_len: int = 150,
-    extra_lines: list[str] | None = None,
-) -> str:
-    """Format a note as a numbered summary line with tags and preview.
-
-    Args:
-        note: The note to format.
-        index: 1-based index for numbered lists (0 = no number prefix).
-        preview_len: Max characters for content preview.
-        extra_lines: Additional indented lines (e.g. "Similarity: 0.85").
-    """
-    prefix = f"{index}. " if index else ""
-    lines = [f"{prefix}{note.title} (ID: {note.id})"]
-    if extra_lines:
-        for line in extra_lines:
-            lines.append(f"   {line}")
-    if note.tags:
-        lines.append(f"   Tags: {format_tag_list(note.tags)}")
-    lines.append(f"   Preview: {content_preview(note.content, preview_len)}")
-    lines.append("")  # trailing blank line
-    return "\n".join(lines) + "\n"
-
-
 def format_note_compact(note: Note) -> str:
     """Format a note as a compact single line for CLI output.
 
@@ -57,25 +31,6 @@ def format_note_compact(note: Note) -> str:
         tag_str = format_tag_list(note.tags[:3])
         lines.append(f"            [{tag_str}]")
     return "\n".join(lines)
-
-
-def format_note_detail(note: Note) -> str:
-    """Format a note with full metadata for display."""
-    lines = [
-        f"# {note.title}",
-        f"ID: {note.id}",
-        f"Type: {note.note_type.value}",
-        f"Created: {note.created_at.isoformat()}",
-        f"Updated: {note.updated_at.isoformat()}",
-    ]
-    if note.tags:
-        lines.append(f"Tags: {format_tag_list(note.tags)}")
-    if note.references:
-        lines.append("References:")
-        for ref in note.references:
-            lines.append(f"  - {ref}")
-    lines.append(f"\n{note.content}")
-    return "\n".join(lines) + "\n"
 
 
 def format_cluster_summary(

--- a/src/slipbox_mcp/services/zettel_service.py
+++ b/src/slipbox_mcp/services/zettel_service.py
@@ -99,10 +99,6 @@ class ZettelService:
         """Get all notes."""
         return self.repository.get_all()
 
-    def search_notes(self, **kwargs: Any) -> List[Note]:
-        """Search for notes based on criteria."""
-        return self.repository.search(**kwargs)
-
     def get_notes_by_tag(self, tag: str) -> List[Note]:
         """Get notes by tag."""
         return self.repository.find_by_tag(tag)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import sys
 import tempfile
-import textwrap
 from pathlib import Path
 
 
@@ -51,7 +50,6 @@ def test_help_shows_base_dir():
 
 def test_warns_on_default_base_dir():
     """Running with no --base-dir and no SLIPBOX_BASE_DIR should warn on stderr."""
-    import os
 
     env = os.environ.copy()
     env.pop("SLIPBOX_BASE_DIR", None)
@@ -80,7 +78,6 @@ def test_status_shows_orphan_count():
 
 def test_status_handles_error_gracefully():
     """Service errors should produce clean 'Error:' messages, not tracebacks."""
-    import os
 
     env = os.environ.copy()
     env["SLIPBOX_BASE_DIR"] = "/nonexistent/readonly/path"
@@ -92,7 +89,6 @@ def test_status_handles_error_gracefully():
 
 def test_search_handles_error_gracefully():
     """Search against a broken path should produce clean error output."""
-    import os
 
     env = os.environ.copy()
     env["SLIPBOX_BASE_DIR"] = "/nonexistent/readonly/path"
@@ -104,7 +100,6 @@ def test_search_handles_error_gracefully():
 
 def test_rebuild_handles_error_gracefully():
     """Rebuild against a broken path should produce clean error output."""
-    import os
 
     env = os.environ.copy()
     env["SLIPBOX_BASE_DIR"] = "/nonexistent/readonly/path"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -5,8 +5,6 @@ from slipbox_mcp.formatting import (
     content_preview,
     format_cluster_summary,
     format_note_compact,
-    format_note_detail,
-    format_note_summary,
     format_tag_list,
 )
 from slipbox_mcp.models.schema import Note, NoteType, Tag
@@ -65,36 +63,6 @@ class TestFormatTagList:
         assert format_tag_list([]) == ""
 
 
-class TestFormatNoteSummary:
-    def test_basic(self):
-        note = make_note()
-        result = format_note_summary(note, index=1)
-        assert "1. Test Note (ID: 20250101T120000000000000)" in result
-        assert "Tags: test, example" in result
-        assert "Preview: Test content here" in result
-
-    def test_with_extra_lines(self):
-        note = make_note()
-        result = format_note_summary(note, index=2, extra_lines=["Similarity: 0.85"])
-        assert "2. Test Note" in result
-        assert "Similarity: 0.85" in result
-
-    def test_no_index(self):
-        note = make_note()
-        result = format_note_summary(note, index=0)
-        assert result.startswith("Test Note (ID:")
-
-    def test_no_tags(self):
-        note = make_note(tags=[])
-        result = format_note_summary(note, index=1)
-        assert "Tags:" not in result
-
-    def test_preview_length(self):
-        note = make_note(content="x" * 200)
-        result = format_note_summary(note, index=1, preview_len=100)
-        assert "x" * 100 + "..." in result
-
-
 class TestFormatNoteCompact:
     def test_basic(self):
         note = make_note()
@@ -117,27 +85,6 @@ class TestFormatNoteCompact:
         result = format_note_compact(note)
         assert "t0, t1, t2" in result
         assert "t3" not in result
-
-
-class TestFormatNoteDetail:
-    def test_includes_full_metadata(self):
-        note = make_note(references=["Ahrens 2017", "https://example.com"])
-        result = format_note_detail(note)
-        assert "# Test Note" in result
-        assert "ID: 20250101T120000000000000" in result
-        assert "Type: permanent" in result
-        assert "Created:" in result
-        assert "Updated:" in result
-        assert "Tags: test, example" in result
-        assert "Ahrens 2017" in result
-        assert "https://example.com" in result
-        assert "Test content here" in result
-
-    def test_no_tags_or_refs(self):
-        note = make_note(tags=[], references=[])
-        result = format_note_detail(note)
-        assert "Tags:" not in result
-        assert "References:" not in result
 
 
 class TestFormatClusterSummary:


### PR DESCRIPTION
Safe `/sc:cleanup` pass — dead code removal + one broken-doc fix. No behavior change.

## `refactor:` — dead code (107 deletions, zero callers)
- **`src/__init__.py`** — empty 0-byte file; `src/` isn't a package (`packages.find` is scoped to `slipbox_mcp*`), already excluded from the built wheel.
- **`ZettelService.search_notes()`** — unused wrapper over `repository.search`; every `search_notes` reference in the repo is the unrelated MCP tool `slipbox_search_notes`.
- **`formatting.format_note_summary` / `format_note_detail`** — used only by their own tests, never by any tool/CLI. Removed the functions and those test cases. Kept `content_preview`, `format_tag_list`, `format_note_compact`, `format_cluster_summary` (used by `cli.py`/tools).
- Cleared pre-existing dead imports in `tests/test_cli.py` (unused `textwrap`, shadowed `os`) that CI never caught — it lints `src/` + `evals/` only.

## `docs:` — fix broken reference + document dev.py
- `CONTRIBUTING.md` "Working in a git worktree" referenced `scripts/new-worktree.sh`, removed in #40 — replaced with plain `git worktree` + `uv` steps.
- Documented `mcp dev src/slipbox_mcp/dev.py` (the MCP Inspector entry point) so `dev.py` is a documented affordance, not an orphan.

## Verification
- `ruff check src/ evals/ tests/` → clean
- `pytest` → 390 passed, 1 skipped (−7 = the removed formatter tests)
- `build` + `twine check` → PASSED; wheel `top_level.txt` still `slipbox_mcp` (the `src/__init__.py` removal changed nothing in packaging)

Both commits are non-releasing (`refactor:`/`docs:`), so release PR #38 stays at 1.4.0.
