### PR TITLE
ci: make LLM evals opt-in instead of path-triggered

### DIFF
--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -1,17 +1,25 @@
 name: LLM Evals
 
+# Opt-in only. This suite is expensive (~$3-5, ~10 min) and runs on a
+# self-hosted runner, so it never triggers automatically — a path-based trigger
+# can't tell a real prompt change from a cosmetic reformat, and would queue
+# (or bill) on incidental edits. Run it deliberately instead:
+#   - add the `run-llm-evals` label to a PR (re-runs on each push while labeled), or
+#   - trigger it manually from the Actions tab (workflow_dispatch).
+# For a quick local check without the runner: `pytest evals/llm/ -v`.
+
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
-    paths:
-      - src/slipbox_mcp/server/descriptions.py
-      - src/slipbox_mcp/server/prompts.py
-      - evals/llm/**
-      - evals/seed_data.py
-      - evals/conftest.py
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   llm-evals:
+    # Skipped (no runner allocated) unless explicitly requested.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-llm-evals')
     runs-on: self-hosted
     timeout-minutes: 20
     steps:

--- a/README.md
+++ b/README.md
@@ -614,25 +614,23 @@ ruff check src/ evals/
 
 | Workflow | Trigger | Runner | What |
 |----------|---------|--------|------|
-| `CI` | Every PR + push to main | GitHub-hosted | Unit + contract tests, ruff |
-| `LLM Evals` | PRs changing prompt files | Self-hosted | 28 LLM evals via claude CLI |
+| `CI` | Every PR + push to main | GitHub-hosted | Unit + contract tests, ruff lint + format |
+| `LLM Evals` | Opt-in (label or manual) | Self-hosted | 28 LLM evals via claude CLI |
 | `Release` | Push to `main` | GitHub-hosted | release-please PR; on its merge, build + publish to PyPI |
 
-The LLM eval workflow triggers only when these files change:
+The LLM eval suite is expensive (~$3-5, ~10 min) and self-hosted, so it **never runs automatically** — a path-based trigger can't distinguish a real prompt change from a cosmetic reformat. Run it deliberately when you change prompt or tool-description semantics:
 
-- `src/slipbox_mcp/server/descriptions.py` (tool descriptions)
-- `src/slipbox_mcp/server/prompts.py` (prompt templates)
-- `evals/llm/**`, `evals/seed_data.py`, `evals/conftest.py`
+- **Add the `run-llm-evals` label** to the PR — it runs, and re-runs on each push while the label is present.
+- **Or trigger it manually** from the Actions tab (`workflow_dispatch`).
+- **Or run it locally** without the runner: `pytest evals/llm/ -v`.
+
+Without a label or manual dispatch, the job is skipped (no runner allocated, no cost).
 
 ### Customizing the eval setup
 
-**If you don't want a self-hosted runner:** Remove `.github/workflows/llm-evals.yml` and run LLM evals locally before merging prompt changes:
+**If you don't want a self-hosted runner:** remove `.github/workflows/llm-evals.yml` and run `pytest evals/llm/ -v` locally before merging prompt changes.
 
-```bash
-pytest evals/llm/ -v
-```
-
-**If you want LLM evals on every PR** (not just prompt changes): Edit `.github/workflows/llm-evals.yml` and remove the `paths:` filter.
+**If you want LLM evals on every PR automatically:** add a `pull_request` trigger with the relevant `paths:` filter and drop the label gate in the job's `if:` — but expect incidental triggers from formatting-only edits.
 
 **To change the default eval model:** Set `EVAL_MODEL` in your environment or in the workflow file. Default is `haiku` for speed/cost.
 


### PR DESCRIPTION
Stops the LLM-eval suite from waking on incidental changes.

## Why
The path-based trigger fired on any edit to prompt/eval files — including cosmetic ones. The repo-wide `ruff format` (#42) reformatted `prompts.py` and the eval files, which queued an LLM-eval run on the (offline) self-hosted runner. A `paths:` filter fundamentally can't distinguish a real prompt change from a whitespace reformat, and `build_skills.py` only fingerprints the prompt templates (not tool descriptions), so a `skills/**` trigger would miss real changes — there's no reliable automatic signal.

## What
Make it **opt-in**:
- Runs only when a PR has the **`run-llm-evals`** label (re-runs on each push while labeled), or via **manual `workflow_dispatch`** from the Actions tab.
- Otherwise the job is **skipped** — no runner allocated, no queue, no cost.
- Local check unchanged: `pytest evals/llm/ -v`.

Created the `run-llm-evals` label. README CI/CD section updated.

`ci:` — non-releasing (release PR #38 stays at 1.4.0).
