### PR TITLE
perf+refactor: hoist hub-note lookup, drop dead content_preview

### DIFF
--- a/src/slipbox_mcp/formatting.py
+++ b/src/slipbox_mcp/formatting.py
@@ -5,14 +5,6 @@ from __future__ import annotations
 from slipbox_mcp.models.schema import Note
 
 
-def content_preview(content: str, max_len: int = 150) -> str:
-    """Truncate content to max_len, replacing newlines with spaces."""
-    preview = content[:max_len].replace("\n", " ")
-    if len(content) > max_len:
-        preview += "..."
-    return preview
-
-
 def format_tag_list(tags) -> str:
     """Format tags as comma-separated string. Accepts Note.tags or plain strings."""
     if not tags:

--- a/src/slipbox_mcp/server/tools/link_tools.py
+++ b/src/slipbox_mcp/server/tools/link_tools.py
@@ -158,19 +158,24 @@ def register_link_tools(server) -> None:
             output = (
                 f"Found {len(linked_notes)} {direction} linked notes for {note_id}:\n\n"
             )
+            # The source (hub) note is the same for every row, so fetch it once
+            # rather than re-reading it from disk on each iteration.
+            source_note = (
+                zettel_service.get_note(str(note_id))
+                if direction in ["outgoing", "both"]
+                else None
+            )
             for i, note in enumerate(linked_notes, 1):
                 output += f"{i}. {note.title} (ID: {note.id})\n"
                 if note.tags:
                     output += f"   Tags: {format_tags(note.tags)}\n"
-                if direction in ["outgoing", "both"]:
-                    source_note = zettel_service.get_note(str(note_id))
-                    if source_note:
-                        for link in source_note.links:
-                            if str(link.target_id) == str(note.id):
-                                output += f"   Link type: {link.link_type.value}\n"
-                                if link.description:
-                                    output += f"   Description: {link.description}\n"
-                                break
+                if source_note:
+                    for link in source_note.links:
+                        if str(link.target_id) == str(note.id):
+                            output += f"   Link type: {link.link_type.value}\n"
+                            if link.description:
+                                output += f"   Description: {link.description}\n"
+                            break
                 if direction in ["incoming", "both"]:
                     for link in note.links:
                         if str(link.target_id) == str(note_id):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -3,7 +3,6 @@
 import datetime
 
 from slipbox_mcp.formatting import (
-    content_preview,
     format_cluster_summary,
     format_note_compact,
     format_tag_list,
@@ -25,30 +24,6 @@ def make_note(**kwargs):
     )
     defaults.update(kwargs)
     return Note(**defaults)
-
-
-class TestContentPreview:
-    def test_truncates_long_content(self):
-        content = "a" * 200
-        result = content_preview(content, max_len=150)
-        assert len(result) == 153  # 150 + "..."
-        assert result.endswith("...")
-
-    def test_replaces_newlines(self):
-        content = "line one\nline two\nline three"
-        result = content_preview(content)
-        assert "\n" not in result
-        assert "line one line two line three" == result
-
-    def test_short_content_unchanged(self):
-        content = "short"
-        result = content_preview(content)
-        assert result == "short"
-
-    def test_custom_max_len(self):
-        content = "a" * 50
-        result = content_preview(content, max_len=10)
-        assert result == "a" * 10 + "..."
 
 
 class TestFormatTagList:


### PR DESCRIPTION
Two safe, verified improvements from a `/sc:improve` analysis pass. Two analysis agents surfaced ~17 candidates; I verified each against the code and kept only the high-confidence, low-risk ones.

## `perf:` — fetch the hub note once (`466c9a0`)
`slipbox_get_linked_notes` re-read the source (hub) note from disk on *every* row of the loop, though `note_id` is constant — O(n) redundant `get_note()` calls for a note with n links. Hoisted out of the loop; output is byte-identical.

## `refactor:` — drop dead `content_preview` (`c4c5460`)
`formatting.content_preview` duplicated `utils.content_preview` (the live one used by search tools). Its only caller (`format_note_summary`) was removed in the earlier dead-code pass (#41), orphaning it. Deleted it + its test; coverage of the live function stays in `test_utils.py`.

## Verification
- `ruff check` + `ruff format --check` → clean (all dirs)
- `pytest` → 386 passed, 1 skipped (−4 = the dead duplicate's tests)

## Deliberately NOT included (reported, not applied)
Verified as **false alarms**: the `IntegrityError` catch "order" (it's one tuple handler checking the message — works fine) and a "title length truncation" bug (SQLite ignores `VARCHAR(255)`, so no truncation; adding the constraint would only reject currently-valid titles).

Real but **deferred for your call** (medium-risk churn right after the cleanup): extracting the repeated enum-validation (4×) and note-list formatting (6×) into helpers; a `TypedDict`/model for cluster `stats` (currently `Dict[str, Any]`); and a low-likelihood frontmatter >2048-byte index-thrash edge. Happy to do any of these as a follow-up if you want them.

Both commits non-releasing (`perf`/`refactor`), so release PR #38 stays at 1.4.0.
