### PR TITLE
refactor: extract parse_enum helper for tool input validation

### DIFF
--- a/src/slipbox_mcp/server/tools/link_tools.py
+++ b/src/slipbox_mcp/server/tools/link_tools.py
@@ -6,7 +6,7 @@ from typing import Optional
 from sqlalchemy import exc as sqlalchemy_exc
 
 from slipbox_mcp.models.schema import LinkType
-from slipbox_mcp.utils import format_tags
+from slipbox_mcp.utils import format_tags, parse_enum
 
 logger = logging.getLogger(__name__)
 
@@ -52,10 +52,9 @@ def register_link_tools(server) -> None:
             bidirectional: If true, creates inverse link from target to source
         """
         try:
-            try:
-                link_type_enum = LinkType(link_type.lower())
-            except ValueError:
-                return f"Invalid link type: {link_type}. Valid types are: {', '.join(t.value for t in LinkType)}"
+            link_type_enum, type_err = parse_enum(link_type, LinkType, "link type")
+            if type_err:
+                return type_err
 
             source_note, target_note = zettel_service.create_link(
                 source_id=source_id,

--- a/src/slipbox_mcp/server/tools/note_tools.py
+++ b/src/slipbox_mcp/server/tools/note_tools.py
@@ -4,7 +4,7 @@ import logging
 from typing import Optional
 
 from slipbox_mcp.models.schema import NoteType
-from slipbox_mcp.utils import format_tags, parse_refs, parse_tags
+from slipbox_mcp.utils import format_tags, parse_enum, parse_refs, parse_tags
 
 logger = logging.getLogger(__name__)
 
@@ -59,10 +59,9 @@ def register_note_tools(server) -> None:
             references: Newline-separated citations to external sources (e.g. "Ahrens, S. (2017). How to Take Smart Notes.\nhttps://zettelkasten.de")
         """
         try:
-            try:
-                note_type_enum = NoteType(note_type.lower())
-            except ValueError:
-                return f"Invalid note type: {note_type}. Valid types are: {', '.join(t.value for t in NoteType)}"
+            note_type_enum, type_err = parse_enum(note_type, NoteType, "note type")
+            if type_err:
+                return type_err
 
             tag_list = parse_tags(tags)
             ref_list = parse_refs(references)
@@ -146,10 +145,9 @@ def register_note_tools(server) -> None:
 
             note_type_enum = None
             if note_type:
-                try:
-                    note_type_enum = NoteType(note_type.lower())
-                except ValueError:
-                    return f"Invalid note type: {note_type}. Valid types are: {', '.join(t.value for t in NoteType)}"
+                note_type_enum, type_err = parse_enum(note_type, NoteType, "note type")
+                if type_err:
+                    return type_err
 
             tag_list = None
             if tags is not None:  # Allow empty string to clear tags

--- a/src/slipbox_mcp/server/tools/search_tools.py
+++ b/src/slipbox_mcp/server/tools/search_tools.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Optional
 
 from slipbox_mcp.models.schema import NoteType
-from slipbox_mcp.utils import content_preview, format_tags, parse_tags
+from slipbox_mcp.utils import content_preview, format_tags, parse_enum, parse_tags
 
 logger = logging.getLogger(__name__)
 
@@ -45,10 +45,9 @@ def register_search_tools(server) -> None:
 
             note_type_enum = None
             if note_type:
-                try:
-                    note_type_enum = NoteType(note_type.lower())
-                except ValueError:
-                    return f"Invalid note type: {note_type}. Valid types are: {', '.join(t.value for t in NoteType)}"
+                note_type_enum, type_err = parse_enum(note_type, NoteType, "note type")
+                if type_err:
+                    return type_err
 
             results = search_service.search_combined(
                 query_text=query, tags=tag_list, note_type=note_type_enum

--- a/src/slipbox_mcp/utils.py
+++ b/src/slipbox_mcp/utils.py
@@ -2,7 +2,10 @@
 
 import logging
 import sys
-from typing import Optional
+from enum import Enum
+from typing import Optional, TypeVar
+
+E = TypeVar("E", bound=Enum)
 
 
 def setup_logging(level: str = "INFO", log_file: Optional[str] = None):
@@ -51,3 +54,19 @@ def content_preview(text: str, max_length: int = 100) -> str:
 def format_tags(tags: list) -> str:
     """Format a list of Tag objects as a comma-separated string."""
     return ", ".join(tag.name for tag in tags)
+
+
+def parse_enum(
+    value: str, enum_cls: type[E], label: str
+) -> tuple[Optional[E], Optional[str]]:
+    """Parse a string into an enum member (case-insensitive by value).
+
+    Returns ``(member, None)`` on success and ``(None, error_message)`` on
+    failure. The error message matches what the MCP tools have always returned
+    for an invalid type, so tool output is unchanged.
+    """
+    try:
+        return enum_cls(value.lower()), None
+    except ValueError:
+        valid = ", ".join(t.value for t in enum_cls)
+        return None, f"Invalid {label}: {value}. Valid types are: {valid}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,10 +4,11 @@
 import logging
 from unittest.mock import patch
 
-from slipbox_mcp.models.schema import Tag
+from slipbox_mcp.models.schema import LinkType, NoteType, Tag
 from slipbox_mcp.utils import (
     content_preview,
     format_tags,
+    parse_enum,
     parse_refs,
     parse_tags,
     setup_logging,
@@ -205,3 +206,29 @@ class TestFormatTags:
     def test_multiple_tags(self):
         tags = [Tag(name="poetry"), Tag(name="craft")]
         assert format_tags(tags) == "poetry, craft"
+
+
+# parse_enum
+class TestParseEnum:
+    """Tests for the parse_enum helper shared by the MCP tools."""
+
+    def test_valid_value_returns_member_and_no_error(self):
+        member, err = parse_enum("permanent", NoteType, "note type")
+        assert member is NoteType.PERMANENT
+        assert err is None
+
+    def test_case_insensitive(self):
+        member, err = parse_enum("REFERENCE", LinkType, "link type")
+        assert member is LinkType.REFERENCE
+        assert err is None
+
+    def test_invalid_value_returns_error_message(self):
+        member, err = parse_enum("bogus", NoteType, "note type")
+        assert member is None
+        # Message must match what the tools have always returned.
+        assert err.startswith("Invalid note type: bogus. Valid types are: ")
+        assert "permanent" in err
+
+    def test_label_appears_in_error(self):
+        _, err = parse_enum("nope", LinkType, "link type")
+        assert err.startswith("Invalid link type: nope.")


### PR DESCRIPTION
Follow-up to #44 — the highest-value item from the `/sc:improve` analysis: centralize the repeated tool-input validation.

## `refactor:` — extract `parse_enum`
The same `try: XType(value.lower()) except ValueError: return "Invalid ..."` was inlined at **4 tool sites** as a nested try/except inside each tool's outer error handler. Replaced with one generic helper:

```python
note_type_enum, type_err = parse_enum(note_type, NoteType, "note type")
if type_err:
    return type_err
```

Sites: `note_tools` (create + update), `search_tools` (search), `link_tools` (create_link). Flattens the nesting and gives one place to change the behavior.

## Byte-identical output — verified, not assumed
The error string is unchanged, and that's **pinned by existing tests**: `test_mcp_server.py` asserts `"Invalid note type: bogus"` / `"Invalid link type: bogus"`, and the tool-contract tests assert the `Invalid ... type` shape. All pass. Added direct unit coverage for `parse_enum` (valid / case-insensitive / invalid-message / label).

- `ruff check` + `format --check` → clean
- `pytest` → 390 passed, 1 skipped (+4 = parse_enum tests)

## What I did NOT extract (and why)
The analysis also flagged "note-list formatting repeated 6×." On inspection that's **not** a clean extraction: each of the 5 search-tool list renderers emits a *different* extra metadata line (`Created`, `Similarity`, `Connections`, `Date`+time, or none) at a *different position* relative to the tags line. A single helper would either change output order — which the LLM evals depend on and the contract test doesn't guard against — or need a fiddly multi-slot signature that saves little. Not worth the risk; left as-is.

`refactor:` — non-releasing (release PR #38 stays at 1.4.0).
