### PR TITLE
refactor: type cluster report stats with a TypedDict

### DIFF
--- a/src/slipbox_mcp/models/cluster_models.py
+++ b/src/slipbox_mcp/models/cluster_models.py
@@ -3,11 +3,25 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional, TypedDict
 
 MIN_CLUSTER_SIZE = 5
 CO_OCCURRENCE_THRESHOLD = 3
 REPORT_PATH = Path("~/.local/share/mcp/slipbox/cluster-analysis.json").expanduser()
+
+
+class ClusterStats(TypedDict):
+    """Aggregate counts attached to a cluster report.
+
+    A TypedDict (not a model) because every producer, consumer, and the JSON
+    round-trip treat it as a plain dict; this just pins the keys and value
+    types for static checking.
+    """
+
+    total_notes: int
+    total_orphans: int
+    clusters_detected: int
+    clusters_needing_structure: int
 
 
 @dataclass
@@ -32,5 +46,5 @@ class ClusterReport:
 
     generated_at: datetime
     clusters: List[ClusterCandidate]
-    stats: Dict[str, Any]
+    stats: ClusterStats
     dismissed_cluster_ids: List[str] = field(default_factory=list)


### PR DESCRIPTION
From the `/sc:improve` follow-up list: give `ClusterReport.stats` a real type.

## Change
`stats` was `Dict[str, Any]`, leaving the four well-known keys unchecked at the producer (`cluster_service`) and **8 consumer sites** (`cluster_tools`, `cli`). Added a `ClusterStats` TypedDict pinning the keys + `int` types.

**A TypedDict, not a pydantic model — deliberately.** `ClusterReport` is a `@dataclass`, and every path treats `stats` as a plain dict: built as a literal, JSON round-tripped in `save_report`/`load_report`, accessed via `report.stats['total_notes']`, and asserted `== {...}` in a test. A model would have forced `.attr` access at all 8 sites and a `.model_dump()` in serialization. The TypedDict gets the static-checking win with **zero** runtime or call-site changes.

## Verification
- `ruff check` → clean
- `mypy` on the cluster files → does **not** flag the producer literal or any consumer subscript (proving the keys/types line up); the 8 errors it reports are all pre-existing and unrelated.
- `pytest` → 390 passed, 1 skipped (unchanged — no behavior change)

`refactor:` — non-releasing.
