### PR TITLE
fix: harden note storage writes and indexing count

### DIFF
--- a/src/slipbox_mcp/cli.py
+++ b/src/slipbox_mcp/cli.py
@@ -13,7 +13,6 @@ import os
 import re
 import signal
 import sys
-import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -31,6 +30,7 @@ from slipbox_mcp.services.cluster_service import ClusterService  # noqa: E402
 from slipbox_mcp.services.search_service import SearchService  # noqa: E402
 from slipbox_mcp.services.zettel_service import ZettelService  # noqa: E402
 from slipbox_mcp.storage.note_repository import NoteRepository  # noqa: E402
+from slipbox_mcp.utils import atomic_write_text  # noqa: E402
 
 
 def cmd_status(args):
@@ -231,26 +231,6 @@ def _rewrite_type_to_permanent(content: str) -> str:
     return "---\n" + new_block + content[end_marker:]
 
 
-def _atomic_write_text(path: Path, text: str) -> None:
-    """Write text to path via temp file + os.replace for atomicity.
-
-    Avoids leaving the target half-written on a crash mid-write.
-    """
-    tmp_dir = path.parent
-    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=tmp_dir)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(text)
-        os.replace(tmp_name, path)
-    except Exception:
-        # Cleanup the temp file on any failure before replace succeeds.
-        try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
-        raise
-
-
 def cmd_audit_references(args):
     """Audit literature notes for missing references.
 
@@ -309,7 +289,7 @@ def cmd_audit_references(args):
             try:
                 content = path.read_text(encoding="utf-8")
                 rewritten = _rewrite_type_to_permanent(content)
-                _atomic_write_text(path, rewritten)
+                atomic_write_text(path, rewritten)
                 succeeded.append(path)
                 print(f"  downgraded {path.name}")
             except (OSError, ValueError) as e:

--- a/src/slipbox_mcp/storage/note_repository.py
+++ b/src/slipbox_mcp/storage/note_repository.py
@@ -25,8 +25,14 @@ from slipbox_mcp.models.db_models import (
 )
 from slipbox_mcp.models.schema import Link, LinkType, Note, NoteType, Tag
 from slipbox_mcp.storage.base import Repository
+from slipbox_mcp.utils import atomic_write_text
 
 logger = logging.getLogger(__name__)
+
+# Upper bound on how far the indexable-file count reads looking for the closing
+# frontmatter fence. Real frontmatter is well under this; the cap just stops a
+# malformed file (opening '---' with no close) from being read end-to-end.
+_MAX_FRONTMATTER_BYTES = 65536
 
 
 class ReferrerSweepError(Exception):
@@ -201,8 +207,21 @@ class NoteRepository(Repository[Note]):
             try:
                 with open(file_path, "r", encoding="utf-8") as f:
                     header = f.read(2048)
-                if not header.startswith("---"):
-                    continue
+                    if not header.startswith("---"):
+                        continue
+                    # The closing fence usually falls within the first read, but
+                    # keep reading (bounded) if it hasn't yet -- otherwise a note
+                    # with large frontmatter is skipped here while the full parser
+                    # still indexes it, so the counts diverge and thrash a full
+                    # rebuild on every construction.
+                    while (
+                        header.find("\n---", 3) == -1
+                        and len(header) < _MAX_FRONTMATTER_BYTES
+                    ):
+                        chunk = f.read(2048)
+                        if not chunk:
+                            break
+                        header += chunk
                 end = header.find("\n---", 3)
                 if end == -1:
                     continue
@@ -558,9 +577,8 @@ class NoteRepository(Repository[Note]):
 
         with self.file_lock:
             try:
-                with open(file_path, "w", encoding="utf-8") as f:
-                    f.write(markdown)
-            except IOError as e:
+                atomic_write_text(file_path, markdown)
+            except OSError as e:
                 raise IOError(f"Failed to write note to {file_path}: {e}")
 
             try:
@@ -626,8 +644,7 @@ class NoteRepository(Repository[Note]):
             original_content = file_path.read_text(encoding="utf-8")
 
             try:
-                with open(file_path, "w", encoding="utf-8") as f:
-                    f.write(markdown)
+                atomic_write_text(file_path, markdown)
 
                 with self.session_factory() as session:
                     db_note = session.scalar(select(DBNote).where(DBNote.id == note.id))
@@ -663,9 +680,8 @@ class NoteRepository(Repository[Note]):
                         self._index_note(note)
             except Exception:
                 try:
-                    with open(file_path, "w", encoding="utf-8") as f:
-                        f.write(original_content)
-                except IOError:
+                    atomic_write_text(file_path, original_content)
+                except OSError:
                     logger.error(
                         "Failed to roll back file %s after DB error", file_path
                     )
@@ -712,9 +728,8 @@ class NoteRepository(Repository[Note]):
             except Exception as e:
                 # Restore file to maintain sync
                 try:
-                    with open(file_path, "w", encoding="utf-8") as f:
-                        f.write(original_content)
-                except IOError:
+                    atomic_write_text(file_path, original_content)
+                except OSError:
                     logger.error("Failed to restore file %s after DB error", file_path)
                 logger.error("DB cleanup failed for note %s, file restored: %s", id, e)
                 raise

--- a/src/slipbox_mcp/utils.py
+++ b/src/slipbox_mcp/utils.py
@@ -1,11 +1,37 @@
 """Utility functions for the Zettelkasten MCP server."""
 
 import logging
+import os
 import sys
+import tempfile
 from enum import Enum
+from pathlib import Path
 from typing import Optional, TypeVar
 
 E = TypeVar("E", bound=Enum)
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically via a temp file + os.replace.
+
+    The replace is atomic on POSIX, so a crash mid-write leaves either the old
+    file or the complete new one -- never a half-written file. The temp file is
+    created in the target directory (same filesystem) so the rename can't fail
+    with EXDEV, and is cleaned up if anything before the replace raises.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 
 def setup_logging(level: str = "INFO", log_file: Optional[str] = None):

--- a/tests/test_storage_sync.py
+++ b/tests/test_storage_sync.py
@@ -143,3 +143,27 @@ class TestLockScope:
         assert lock_held_during_index == [True], (
             "file_lock was not held during DB indexing"
         )
+
+
+class TestIndexableCount:
+    """Verify the indexable-file count matches what the parser indexes."""
+
+    def test_counts_note_with_frontmatter_over_read_buffer(self, note_repository):
+        """A note whose frontmatter exceeds the initial 2048-byte read is still
+        counted, so file/DB counts don't diverge and thrash a full rebuild."""
+        big_value = "x" * 3000  # pushes the closing fence well past 2048 bytes
+        content = (
+            "---\n"
+            "id: 20250101T120000000000000\n"
+            "title: Big Frontmatter\n"
+            "type: permanent\n"
+            f"note: '{big_value}'\n"
+            "---\n\nbody\n"
+        )
+        assert content.index("\n---", 3) > 2048  # the scenario under test
+
+        before = note_repository._count_indexable_files()
+        (note_repository.notes_dir / "big.md").write_text(content, encoding="utf-8")
+        after = note_repository._count_indexable_files()
+
+        assert after == before + 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from slipbox_mcp.models.schema import LinkType, NoteType, Tag
 from slipbox_mcp.utils import (
+    atomic_write_text,
     content_preview,
     format_tags,
     parse_enum,
@@ -232,3 +233,24 @@ class TestParseEnum:
     def test_label_appears_in_error(self):
         _, err = parse_enum("nope", LinkType, "link type")
         assert err.startswith("Invalid link type: nope.")
+
+
+# atomic_write_text
+class TestAtomicWriteText:
+    """Tests for the atomic file-write helper."""
+
+    def test_writes_content(self, tmp_path):
+        target = tmp_path / "note.md"
+        atomic_write_text(target, "hello")
+        assert target.read_text(encoding="utf-8") == "hello"
+
+    def test_overwrites_existing(self, tmp_path):
+        target = tmp_path / "note.md"
+        target.write_text("old", encoding="utf-8")
+        atomic_write_text(target, "new")
+        assert target.read_text(encoding="utf-8") == "new"
+
+    def test_leaves_no_temp_file(self, tmp_path):
+        target = tmp_path / "note.md"
+        atomic_write_text(target, "data")
+        assert [p.name for p in tmp_path.iterdir()] == ["note.md"]


### PR DESCRIPTION
The last two items from the `/sc:improve` follow-up list — both real storage-layer robustness fixes.

## `fix:` — atomic note writes
`create()` / `update()` (and update's recovery paths) wrote markdown with a plain truncating `open(..., "w")`, which can leave a **half-written file** if the process dies mid-write. They now go through a shared `utils.atomic_write_text()` (temp file + `os.replace` — atomic on POSIX). The helper was promoted from the duplicate that already lived in `cli.py`; `cli.py` now imports the shared one (one fewer copy).

## `fix:` — large-frontmatter index count
`_count_indexable_files()` read only the first **2048 bytes**, so a note whose frontmatter exceeded that had its closing `---` missed → it was skipped from the count while the full parser still indexed it → the file/DB counts diverged → a **full rebuild thrashed on every construction**. It now keeps reading (bounded to 64 KB) until the closing fence, matching what the parser counts.

## Why one PR / one commit
Both are small storage-robustness fixes co-located in `note_repository.py` (the count constant and the atomic-write import interleave), so a clean hunk-split would be fragile surgery for little gain. Bundled with a two-part commit body.

## Verification
- New tests: `atomic_write_text` (writes/overwrites/no-temp-leftover) and counting a note whose frontmatter sits past the read buffer (fence verified at byte 3068, so it genuinely exercises the fixed path — the old code skipped it).
- `ruff check` + `format --check` → clean · `pytest` → 394 passed, 1 skipped

`fix:` — these fold into the pending 1.4.0 release's changelog (minor already wins; no extra bump).
