### PR TITLE
test: cover atomic-write failure path and refine new tests

### DIFF
--- a/tests/test_storage_sync.py
+++ b/tests/test_storage_sync.py
@@ -148,22 +148,33 @@ class TestLockScope:
 class TestIndexableCount:
     """Verify the indexable-file count matches what the parser indexes."""
 
+    # _count_indexable_files() first reads this many bytes looking for the
+    # closing frontmatter fence; the bug was skipping notes whose fence fell
+    # beyond it. The padding below deliberately pushes the fence past this.
+    INITIAL_READ_BYTES = 2048
+
     def test_counts_note_with_frontmatter_over_read_buffer(self, note_repository):
-        """A note whose frontmatter exceeds the initial 2048-byte read is still
-        counted, so file/DB counts don't diverge and thrash a full rebuild."""
-        big_value = "x" * 3000  # pushes the closing fence well past 2048 bytes
+        """A note whose frontmatter exceeds the initial read is still counted,
+        so file/DB counts don't diverge and thrash a full rebuild."""
+        # Arrange: a valid note whose closing fence sits past the initial read.
+        padding = "x" * (self.INITIAL_READ_BYTES + 1000)
         content = (
             "---\n"
             "id: 20250101T120000000000000\n"
             "title: Big Frontmatter\n"
             "type: permanent\n"
-            f"note: '{big_value}'\n"
+            f"note: '{padding}'\n"
             "---\n\nbody\n"
         )
-        assert content.index("\n---", 3) > 2048  # the scenario under test
+        fence_pos = content.index("\n---", 3)
+        assert fence_pos > self.INITIAL_READ_BYTES, (
+            f"test setup invalid: fence at {fence_pos} is within the initial read"
+        )
 
+        # Act: count before and after dropping the big-frontmatter note in.
         before = note_repository._count_indexable_files()
         (note_repository.notes_dir / "big.md").write_text(content, encoding="utf-8")
         after = note_repository._count_indexable_files()
 
-        assert after == before + 1
+        # Assert: the note is counted (would be skipped by the pre-fix reader).
+        assert after == before + 1, "large-frontmatter note was not counted"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,8 @@
 import logging
 from unittest.mock import patch
 
+import pytest
+
 from slipbox_mcp.models.schema import LinkType, NoteType, Tag
 from slipbox_mcp.utils import (
     atomic_write_text,
@@ -253,4 +255,32 @@ class TestAtomicWriteText:
     def test_leaves_no_temp_file(self, tmp_path):
         target = tmp_path / "note.md"
         atomic_write_text(target, "data")
-        assert [p.name for p in tmp_path.iterdir()] == ["note.md"]
+        survivors = [p.name for p in tmp_path.iterdir()]
+        assert survivors == ["note.md"], f"leaked temp file(s): {survivors}"
+
+    def test_failure_cleans_up_temp_and_propagates(self, tmp_path):
+        # The replace is what publishes the temp file; force it to fail so we
+        # exercise the cleanup branch the helper exists for.
+        target = tmp_path / "note.md"
+
+        with patch("slipbox_mcp.utils.os.replace", side_effect=OSError("boom")):
+            with pytest.raises(OSError, match="boom"):
+                atomic_write_text(target, "data")
+
+        assert not target.exists(), "target created despite failed write"
+        survivors = [p.name for p in tmp_path.iterdir()]
+        assert survivors == [], f"temp file leaked on failure: {survivors}"
+
+    def test_failure_leaves_original_intact(self, tmp_path):
+        # Atomicity: a write that fails mid-flight must not corrupt or truncate
+        # the existing file -- the reader still sees the old, complete content.
+        target = tmp_path / "note.md"
+        target.write_text("original", encoding="utf-8")
+
+        with patch("slipbox_mcp.utils.os.replace", side_effect=OSError("boom")):
+            with pytest.raises(OSError):
+                atomic_write_text(target, "replacement")
+
+        assert target.read_text(encoding="utf-8") == "original"
+        survivors = [p.name for p in tmp_path.iterdir()]
+        assert survivors == ["note.md"], f"temp file leaked on failure: {survivors}"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -15,11 +15,18 @@ import pytest
 
 from slipbox_mcp import __version__
 
+# Distribution name on PyPI (note: differs from the import name slipbox_mcp).
+DIST_NAME = "slipbox-mcp"
+# Simple PEP 440 release shape: N.N.N with an optional pre/post/dev suffix.
+PEP440_RELEASE_RE = r"^\d+\.\d+\.\d+([.\-+].*)?$"
+
 
 def test_version_is_pep440_shaped():
     # The release workflow strips a leading `v` from the git tag and compares
     # the remainder to __version__; a malformed value would break that compare.
-    assert re.match(r"^\d+\.\d+\.\d+([.\-+].*)?$", __version__), __version__
+    assert re.match(PEP440_RELEASE_RE, __version__), (
+        f"__version__ {__version__!r} is not a PEP 440 release string"
+    )
 
 
 def test_installed_metadata_matches_dunder():
@@ -27,10 +34,13 @@ def test_installed_metadata_matches_dunder():
     # __version__. CI installs the package (editable), so metadata is present;
     # skip cleanly if the tree was never installed.
     try:
-        installed = version("slipbox-mcp")
+        installed = version(DIST_NAME)
     except PackageNotFoundError:
-        pytest.skip("slipbox-mcp not installed; run `pip install -e .`")
-    assert installed == __version__
+        pytest.skip(f"{DIST_NAME} not installed; run `pip install -e .`")
+    assert installed == __version__, (
+        f"built metadata {installed!r} != __version__ {__version__!r}; "
+        "dynamic-version wiring is out of sync"
+    )
 
 
 def test_server_version_derives_from_dunder():


### PR DESCRIPTION
`/refine-tests` pass over the tests authored this session (#34–#47). They were already in good shape — descriptive names, one concept each, precise assertions — so this is targeted, not a rewrite.

## The one finding that mattered — a real coverage gap
`TestAtomicWriteText` only tested the happy path. `atomic_write_text` exists **for** its failure branch (clean up the temp file, don't corrupt the original on a mid-write crash), and that was untested. Added two tests, patching `os.replace` to fail:
- `test_failure_cleans_up_temp_and_propagates` — temp file is removed, `OSError` propagates, target isn't created.
- `test_failure_leaves_original_intact` — the atomicity invariant: a failed write leaves the existing file's old content untouched.

**Verified non-tautological:** neutering the cleanup branch in `utils.py` makes the first test fail (leaked temp detected); restoring it passes. So the test actually guards the invariant.

## Clarity refinements (no behavior change)
- `TestIndexableCount`: named the `INITIAL_READ_BYTES = 2048` boundary (it silently mirrored the source's `f.read(2048)`) and made the AAA structure explicit.
- `test_version.py`: extracted `DIST_NAME` (the PyPI name differs from the import name) and `PEP440_RELEASE_RE`; added a failure message to the dynamic-version drift assert.
- Added debug context to a few assertions where the bare value wasn't enough.

## What I deliberately left alone
Resisted cosmetic churn — no failure messages bolted onto assertions pytest already introspects well, no factory methods for trivially-clear test data. The suite was solid; this fills the gap and sharpens the magic numbers.

`pytest` → 396 passed, 1 skipped (+2). `ruff` clean. `test:` — non-releasing.
