### PR TITLE
test: fix tautological, weak, and skipped tests from audit

### DIFF
--- a/evals/tool_contracts/test_output_format.py
+++ b/evals/tool_contracts/test_output_format.py
@@ -47,14 +47,18 @@ class TestSearchToolOutputs:
 
     def test_search_no_results(self, tool):
         result = tool("slipbox_search_notes")(query="xyznonexistent")
-        assert "no" in result.lower() or "0" in result
+        # Assert the real no-results string. ("no" alone is a substring of
+        # "notes" and matched almost any output.)
+        assert "No matching notes found" in result
 
     def test_find_orphaned_notes(self, tool):
         tool("slipbox_create_note")(
             title="Lonely Note", content="No links", tags="orphan"
         )
         result = tool("slipbox_find_orphaned_notes")()
-        assert "Lonely Note" in result or "orphan" in result.lower()
+        # The created note must actually be listed. (The old `or "orphan"`
+        # matched the "orphaned notes" header even when the note was absent.)
+        assert "Lonely Note" in result
 
 
 class TestLinkToolOutputs:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,21 +59,21 @@ def test_warns_on_default_base_dir():
     assert "Warning: No --base-dir or SLIPBOX_BASE_DIR set" in result.stderr
 
 
-def test_base_dir_flag_accepted():
-    """--base-dir /tmp should be accepted without error."""
-    result = _run_cli("--base-dir", "/tmp", "status")
+def test_base_dir_flag_accepted(tmp_path):
+    """--base-dir should be accepted without error."""
+    result = _run_cli("--base-dir", str(tmp_path), "status")
     assert result.returncode == 0
 
 
-def test_orphans_command_runs():
+def test_orphans_command_runs(tmp_path):
     """slipbox orphans should exit 0."""
-    result = _run_cli("--base-dir", "/tmp", "orphans")
+    result = _run_cli("--base-dir", str(tmp_path), "orphans")
     assert result.returncode == 0
 
 
-def test_status_shows_orphan_count():
+def test_status_shows_orphan_count(tmp_path):
     """slipbox status output should contain 'Orphans:'."""
-    result = _run_cli("--base-dir", "/tmp", "status")
+    result = _run_cli("--base-dir", str(tmp_path), "status")
     assert result.returncode == 0
     assert "Orphans:" in result.stdout
 

--- a/tests/test_cluster_service.py
+++ b/tests/test_cluster_service.py
@@ -432,7 +432,17 @@ class TestDetectClusters:
                 )
             )
         report = service.detect_clusters(notes=notes)
+
+        # 6 notes all sharing alpha+beta form exactly one cluster. The previous
+        # isinstance-only assertion passed even if the pipeline found nothing.
         assert isinstance(report, ClusterReport)
+        assert report.stats["total_notes"] == 6
+        assert len(report.clusters) == 1, (
+            f"expected one cluster, got {len(report.clusters)}"
+        )
+        cluster = report.clusters[0]
+        assert cluster.note_count == 6
+        assert set(cluster.tags) == {"alpha", "beta"}
 
 
 class TestSuggestTitle:

--- a/tests/test_fts5_search.py
+++ b/tests/test_fts5_search.py
@@ -231,22 +231,26 @@ def test_search_by_text_non_fts5_operational_error_reraises(
             search_service.search_by_text("test query")
 
 
-def test_search_combined_fts5_syntax_error_returns_empty(
-    zettel_service, search_service
-):
-    """When FTS5 raises a syntax error, search_combined returns [] via _run_fts5_query."""
-    zettel_service.create_note(
-        title="Fallback Note",
-        content="Content for fallback test.",
-        tags=["fallback-tag"],
+def test_run_fts5_query_swallows_fts5_syntax_error(search_service):
+    """A genuine FTS5 syntax error (message contains 'fts5') is swallowed and
+    returns []. The error is injected at the session so the real except branch
+    in _run_fts5_query runs -- the previous version patched _run_fts5_query
+    itself and so asserted nothing about the swallow logic."""
+    fts5_error = OperationalError(
+        'fts5: syntax error near """',
+        params=None,
+        orig=Exception("fts5: syntax error"),
     )
-    with patch.object(search_service, "_run_fts5_query", return_value=[]):
-        result = search_service.search_combined(
-            query_text="fallback query", tags=["fallback-tag"]
-        )
+    with patch.object(
+        search_service.zettel_service.repository, "session_factory"
+    ) as mock_sf:
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=False)
+        session.execute.side_effect = fts5_error
+        mock_sf.return_value = session
 
-    assert isinstance(result, list)
-    assert result == []
+        assert search_service._run_fts5_query("anything") == []
 
 
 def test_fts5_query_returns_scored_rows(search_service, zettel_service):

--- a/tests/test_semantic_links.py
+++ b/tests/test_semantic_links.py
@@ -180,8 +180,9 @@ class TestSemanticLinks:
             )
 
     def test_custom_bidirectional_link_types(self, zettel_service):
-        """Test bidirectional links with custom inverse types."""
-        # Create test notes
+        """A bidirectional link with an explicit bidirectional_type sets the
+        reverse link to that type rather than the default inverse."""
+        # Arrange
         source_note = zettel_service.create_note(
             title="Custom Bidirectional Source",
             content="Source note content for custom bidirectional links",
@@ -195,42 +196,31 @@ class TestSemanticLinks:
             tags=["test", "custom-bidirectional"],
         )
 
-        # Create bidirectional link with explicit inverse type
-        # The second parameter should be a specific bidirectional_type, not a boolean
-        # However, since the ZettelService interface doesn't support this directly,
-        # we'll need to modify the test or mock the lower-level function
-
-        # For now, we'll test this using two separate directional links
-        source, _ = zettel_service.create_link(
+        # Act: a single bidirectional call with an explicit reverse type. This
+        # exercises the bidirectional_type parameter, which was previously not
+        # covered anywhere -- the old version of this test faked it with two
+        # separate one-directional links.
+        zettel_service.create_link(
             source_id=source_note.id,
             target_id=target_note.id,
             link_type=LinkType.EXTENDS,
-            description="Forward direction",
+            bidirectional=True,
+            bidirectional_type=LinkType.QUESTIONS,
         )
 
-        target, _ = zettel_service.create_link(
-            source_id=target_note.id,
-            target_id=source_note.id,
-            link_type=LinkType.QUESTIONS,  # Custom inverse type (not the expected EXTENDED_BY)
-            description="Custom backward direction",
-        )
-
-        # Verify links
+        # Assert: forward link is EXTENDS; the auto-created reverse link uses the
+        # custom QUESTIONS type, not the default inverse (EXTENDED_BY).
         source_note = zettel_service.get_note(source_note.id)
         target_note = zettel_service.get_note(target_note.id)
 
-        # Check outgoing link from source
         source_links = [
             link for link in source_note.links if link.target_id == target_note.id
         ]
         assert len(source_links) == 1, (
             f"Expected 1 source link, got {len(source_links)}"
         )
-        assert source_links[0].link_type == LinkType.EXTENDS, (
-            f"Expected EXTENDS, got {source_links[0].link_type.value}"
-        )
+        assert source_links[0].link_type == LinkType.EXTENDS
 
-        # Check outgoing link from target (custom inverse)
         target_links = [
             link for link in target_note.links if link.target_id == source_note.id
         ]
@@ -238,7 +228,8 @@ class TestSemanticLinks:
             f"Expected 1 target link, got {len(target_links)}"
         )
         assert target_links[0].link_type == LinkType.QUESTIONS, (
-            f"Expected QUESTIONS (custom inverse), got {target_links[0].link_type.value}"
+            "reverse link should use the custom bidirectional_type, got "
+            f"{target_links[0].link_type.value}"
         )
 
     def test_links_persistence_through_save_and_load(self, zettel_service):

--- a/tests/test_storage_sync.py
+++ b/tests/test_storage_sync.py
@@ -114,10 +114,6 @@ class TestUpdateAtomicity:
         assert file_path.read_text() == original_content
 
 
-@pytest.mark.skipif(
-    not hasattr(__import__("threading").RLock(), "locked"),
-    reason="RLock.locked() requires Python 3.14+",
-)
 class TestLockScope:
     """Verify file_lock covers both file and DB operations."""
 
@@ -128,7 +124,11 @@ class TestLockScope:
         original_index = note_repository._index_note
 
         def tracking_index(note):
-            lock_held_during_index.append(note_repository.file_lock.locked())
+            # _index_note runs on the same thread as create(), so RLock._is_owned()
+            # reports whether the lock is held here. (Unlike RLock.locked(), which
+            # is Python 3.14+, _is_owned() works on every version -- the old
+            # skipif silently disabled this invariant on CI's 3.13.)
+            lock_held_during_index.append(note_repository.file_lock._is_owned())
             return original_index(note)
 
         note = Note(

--- a/tests/test_zettel_service.py
+++ b/tests/test_zettel_service.py
@@ -257,11 +257,16 @@ def test_find_similar_notes(zettel_service):
     # Act
     similar = zettel_service.find_similar_notes(note1.id, 0.0)
 
-    # Assert
+    # Assert: both linked notes surface, and results are ranked by descending
+    # similarity. The ranking is the real contract -- the previous `or`
+    # assertion passed even if the scorer returned everything in any order.
     similar_ids = [n.id for n, _ in similar]
-    assert len(similar) > 0, "Expected at least one similar note"
-    assert note2.id in similar_ids or note3.id in similar_ids, (
-        "At least one linked/shared-tag note should appear in similar results"
+    scores = [score for _, score in similar]
+    assert note2.id in similar_ids and note3.id in similar_ids, (
+        "both linked notes should appear among similar results"
+    )
+    assert scores == sorted(scores, reverse=True), (
+        "similar notes must be ranked by descending similarity"
     )
 
 


### PR DESCRIPTION
Fixes the verified top findings from the test-suite audit. Every claim was checked against the code first — and two of the audit's claims were wrong, which changed what I did.

## Fixed (verified real)
- **Coverage gap — `bidirectional_type` was untested.** `test_custom_bidirectional_link_types` *faked* a custom inverse with two one-directional links, its comment wrongly claiming the interface "doesn't support this directly." `create_link` has had a `bidirectional_type` param all along. Rewrote it to actually pass `bidirectional_type` and assert the reverse link gets the custom type.
- **Silently-skipped invariant.** `TestLockScope` was `skipif`'d on `RLock.locked()` (Python 3.14+), so the "lock held during `_index_note`" check **never ran on CI** (3.13). Switched to `RLock._is_owned()` (all versions) — the invariant now actually runs.
- **Three tautologies.** FTS5 syntax-error test patched the very helper it should exercise → now injects the error at the session so the real swallow branch runs. Similar-notes test used `threshold=0.0` + `or` (passed even if scoring were broken) → now requires both linked notes and asserts descending-rank ordering. Cluster test asserted only `isinstance` → now asserts cluster count, `note_count`, tags, and `stats`.
- **Two weak contract asserts.** `"no" in result` matched the substring inside "notes"; `or "orphan"` matched the section header — both passed for almost any output. Tightened to the real strings.
- **`/tmp` pollution.** Three CLI tests wrote real data into world-writable `/tmp/data`; now use `tmp_path`.

## Where the audit was wrong (so I did *less*)
- It called the missing **default-inverse** coverage a headline gap ("a broken inverse mapping ships green"). Reading the file showed `test_bidirectional_semantic_links` already covers it exhaustively — all 12 link types assert the target's `expected_inverse`. So I **dropped** the redundant inverse test I'd initially added; only the genuinely-missing `bidirectional_type` override is new coverage.
- The `IntegrityError` "dead handler" and "title truncation" findings (from the earlier improve pass) were already verified false.

## Verification
- `pytest` → **397 passed, 0 skipped** (was 396 + 1 skipped — the skip is now a real passing assertion; no padding tests added)
- `ruff check` + `format --check` → clean
- The lock fix was validated by the un-skip; the bidirectional/cluster/contract asserts all hold against real output.

`test:` — non-releasing.
