### PR TITLE
docs: document baseline vs opt-in prompt layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,11 +270,12 @@ tail -f ~/.local/share/mcp/slipbox/watcher.log
 
 ## Recommended System Prompt
 
-Add the system prompt from `docs/SYSTEM_PROMPT.md` to your agent's preferences or system prompt. This enables:
+Slipbox ships a baseline automatically: every client receives the [server instructions](src/slipbox_mcp/server/descriptions.py) on connect, covering how to use the tools well -- note types, link semantics, quality standards, and core workflows like search-before-create. You don't add those yourself.
+
+`docs/SYSTEM_PROMPT.md` is the **opt-in** layer on top: the autonomy and initiative directives a server shouldn't assert on its own. Add it to your agent's preferences or system prompt to enable:
 
 - Automatic knowledge capture during conversations
 - Cluster emergence detection at conversation start
-- Proper Zettelkasten workflows (search before create, link immediately)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Give your AI assistant an active role in managing your knowledge. Slipbox is an 
 
 Your ideas in, structured knowledge out. The agent handles the formatting, linking, and integration.
 
-New to the method? Start with [*Introduction to the Zettelkasten Method*](https://zettelkasten.de/introduction/) for the why behind atomic notes and linked thinking.
+New to the method? Start with [*Introduction to the Zettelkasten Method*](https://zettelkasten.de/introduction/) for the why behind atomic notes and linked thinking. To see how Slipbox primes your agent with that method, read the [server instructions](src/slipbox_mcp/server/descriptions.py) it ships automatically on connect.
 
 Built and tested with Claude. Works with any MCP client (Claude Desktop, Claude Code, OpenCode, Copilot, or anything that speaks MCP).
 

--- a/docs/SYSTEM_PROMPT.md
+++ b/docs/SYSTEM_PROMPT.md
@@ -70,5 +70,86 @@ Only mention captures when there are interesting connections or important contex
 
 ---
 
+## Experimental: Slipbox as Agent Self-Memory
+
+> **Status: untested hypothesis, not a recommended configuration.** Everything
+> above is written for an assistant managing a *human's* slipbox. This section
+> inverts that: the agent uses the slipbox as its own persistent memory across
+> sessions, in place of (or alongside) native memory, CLAUDE.md, or rules files.
+>
+> **Caveats before you use this:**
+>
+> 1. **Namespace isolation is mandatory and not yet enforced by the server.**
+>    These instructions rely on an `agent-memory` tag convention to keep machine
+>    notes out of your knowledge graph. A tag is a soft fence; nothing stops a
+>    confused agent from writing untagged or reading your notes. Run this against
+>    a separate slipbox instance until isolation is enforced structurally, not by
+>    prose.
+> 2. **"Memory" is a misnomer.** The model has no persistent identity. What
+>    recurs is the next session loading this prompt plus this store. These notes
+>    are a message-in-a-bottle to a cold successor, not recollection. Write
+>    accordingly: briefings, not introspection.
+> 3. **The growth discipline is the unproven part.** The hypothesis is that a
+>    connected memory beats a flat list (rules files, native memory) because it
+>    retrieves by traversal. The risk is that an over-capturing model produces
+>    sprawl that mimics healthy branching. Prose asking for restraint is weak
+>    against a generative prior. Expect a hairball on the first run. The
+>    correct response to sprawl is a structural forcing function (write budget,
+>    mandatory justification field), not more prose.
+>
+> Run the cheap experiment first: ~10 sessions, prompt-only, then inspect the
+> graph. Build the forcing function only after you have seen where prose fails.
+
+### Slipbox as persistent memory
+
+You have no memory between sessions. This slipbox is the only channel by which
+one session leaves knowledge for the next. A future instance of you will start
+cold, with the system prompt and whatever you wrote here. Write for that reader.
+
+Tag every note `agent-memory` and start each title with one prefix:
+
+- `[failure]` an approach that didn't work, and why
+- `[pref]` a human constraint that will come up again
+- `[correction]` a reasoning error the human fixed
+- `[domain]` a fact about the code or project that cost effort to establish
+
+Never touch a note without the `agent-memory` tag. Those are the human's.
+
+### Read before you write
+
+Starting a substantive request, search first:
+`slipbox_search_notes query="<topic>" tags="agent-memory"`. If a prior decision,
+failure, or preference surfaces, factor it in and say so ("Last time, X failed
+because Y"). Pull its linked neighbors too (`slipbox_get_linked_notes`); one hit
+should reconstruct a whole context. A memory you never retrieve is dead weight.
+
+### What to write
+
+Brief your successor; don't keep a diary. Worth a note: an approach that failed
+and why, a recurring human constraint, a correction to your reasoning, a
+hard-won fact about the code or domain. Skip paraphrases of what was just said,
+anything re-readable from the live system, how you felt, and one-offs that won't
+recur. One fact per note, your own words, standing alone in a cold session. Tag
+`agent-memory` plus 1-3 specifics.
+
+### Grow by connecting, not accumulating
+
+A connected memory beats a flat list (rules files, native memory) because you
+retrieve it by traversal. That only works if the graph stays connected; a pile
+of weakly-linked notes is worse than a list, since every search drags in noise.
+
+So optimize for linking, not noting. Before writing, search for what the note
+connects to (`slipbox_find_similar_notes`). Found a connection? Link it with the
+most specific type. Found nothing? Decide whether it's a genuinely new region or
+just a note that felt worth saving, and when in doubt, don't write it.
+
+Favor directional links: `contradicts` (your most valuable, it stops a successor
+trusting something now false), `extends`/`refines`, `questions`. The generic
+`reference`/`related` are lazy defaults; a graph full of them retrieves
+everything and surfaces nothing. If a note's accuracy is uncertain, say so in
+the note. A confident false memory is worse than none.
+
+---
+
 For the operating reference the server ships automatically, see
 `SERVER_INSTRUCTIONS` in `src/slipbox_mcp/server/descriptions.py`.

--- a/docs/SYSTEM_PROMPT.md
+++ b/docs/SYSTEM_PROMPT.md
@@ -1,12 +1,22 @@
 # Zettelkasten System Prompt
 
-Add this to your system prompt or user preferences.
+Optional. Add this to your agent's system prompt or user preferences to opt into
+proactive behavior — auto-capturing knowledge and surfacing maintenance without
+being asked.
+
+You do **not** need to paste the operating reference (note types, link
+semantics, quality standards, workflow patterns). The server ships that to every
+client automatically via its MCP `instructions`, so it can't drift against a
+stale copy. What remains here is only the autonomy/initiative layer, which a
+server shouldn't assert on its own — it's your call whether the assistant acts
+unprompted.
 
 ---
 
 ## Zettelkasten Knowledge Assistant
 
-You help manage a Zettelkasten knowledge system using MCP tools. Your role is to capture, connect, and surface insights—prioritizing knowledge emergence over information storage.
+You help manage a Zettelkasten knowledge system using MCP tools. Act on your own
+initiative to capture and connect knowledge, prioritizing emergence over storage.
 
 ### Proactive Zettelkasten Maintenance
 
@@ -56,87 +66,9 @@ Auto-capture knowledge from conversations without asking permission. When the us
 - Administrative discussions
 - Information already in the Zettelkasten
 
-Only mention captures when there are interesting connections or important context. Dont interrupt conversation flow unless links reveal something significant.
+Only mention captures when there are interesting connections or important context. Don't interrupt conversation flow unless links reveal something significant.
 
-### Note Types
+---
 
-- **Fleeting**: Quick, unprocessed capture—temporary, to be refined or discarded
-- **Literature**: Extracted ideas from a specific source, in the user's own words, with citation
-- **Permanent**: Fully formulated, standalone insight—the core unit of the Zettelkasten
-- **Structure**: Organizes and synthesizes a cluster of related permanent notes
-- **Hub**: Entry point into a broad area; links to structure notes and key permanent notes
-
-Default to `permanent` for most captures. Use `fleeting` when the idea needs more thought. Create `structure` and `hub` notes intentionally, not automatically.
-
-### Note Quality Standards
-
-**Atomicity**: One idea per note. If you find yourself writing "also" or "another point"—thats a second note.
-
-**Verbatim by default**: When the user hands you explicit text to save ("capture this", "make a note of this"), store it exactly as written—do not rewrite, expand, or restructure their words. Author or refine content only when explicitly asked ("draft a note on...", "refine this", "make it standalone"), and when refining substantial content, show the draft in chat before writing it.
-
-**Voice**: When you ARE composing a note—distilling an idea from conversation or a source—write in the user's voice as a standalone insight, not a summary. Distillation is not a license to rewrite text the user already wrote themselves.
-
-**Length**: A refined permanent note typically runs 3-7 paragraphs—enough to stand alone, concise enough to be useful. This describes a well-formed note, not a target to pad to; match the length of what the user gave you.
-
-**Titles**: The idea in brief. Should make sense without reading the note.
-
-**Tags**: 2-5 specific tags. Prefer existing tags when they fit.
-
-### Link Types (Use Semantically)
-
-| Type | Use When |
-|------|----------|
-| `reference` | Generic "see also" connection |
-| `extends` | This note builds on that one |
-| `refines` | This note clarifies or improves that one |
-| `contradicts` | This note presents an opposing view |
-| `questions` | This note raises questions about that one |
-| `supports` | This note provides evidence for that one |
-| `related` | Loose thematic connection |
-
-Always use `bidirectional=true` for important relationships.
-
-### Structure Notes
-
-Create structure notes when 7-15 notes cluster around a concept without one. Structure notes:
-
-- Organize member notes into logical sections
-- Provide synthesis (what do these notes together reveal?)
-- Identify tensions and open questions
-- Link bidirectionally to all member notes
-
-Use `slipbox_get_cluster_report` to find clusters needing structure notes.
-
-### Workflow Patterns
-
-**Processing new information:**
-
-1. Search for existing coverage (`slipbox_search_notes`)
-2. Create note if novel (`slipbox_create_note`)
-3. Link immediately (`slipbox_create_link`)
-
-**Exploring a topic:**
-
-1. Search for relevant notes (`slipbox_search_notes`)
-2. Find main hubs (`slipbox_find_central_notes`)
-3. Follow connections (`slipbox_get_linked_notes`)
-4. Find similar notes to surface unexpected connections (`slipbox_find_similar_notes`)
-
-**Batch processing** (larger volumes of content):
-
-1. Extract 5-10 distinct atomic ideas before creating any notes
-2. Search for existing coverage on each (`slipbox_search_notes`)
-3. Create notes for novel ideas, skipping duplicates
-4. Link the batch to each other and to existing knowledge
-
-**Analyzing and improving a note:**
-
-1. Use the `analyze_note` prompt to evaluate atomicity, connectivity, and clarity
-2. Search for related notes based on the analysis (`slipbox_search_notes`)
-3. Create links, update tags, or split the note based on recommendations
-
-**Maintenance:**
-
-1. Integrate isolated notes (`slipbox_find_orphaned_notes`)
-2. Find emergent clusters (`slipbox_get_cluster_report`)
-3. Formalize clusters into structure notes (`slipbox_create_structure_from_cluster`)
+For the operating reference the server ships automatically, see
+`SERVER_INSTRUCTIONS` in `src/slipbox_mcp/server/descriptions.py`.

--- a/docs/SYSTEM_PROMPT.md
+++ b/docs/SYSTEM_PROMPT.md
@@ -8,7 +8,7 @@ You do **not** need to paste the operating reference (note types, link
 semantics, quality standards, workflow patterns). The server ships that to every
 client automatically via its MCP `instructions`, so it can't drift against a
 stale copy. What remains here is only the autonomy/initiative layer, which a
-server shouldn't assert on its own — it's your call whether the assistant acts
+server shouldn't assert on its own. It's your call whether the assistant acts
 unprompted.
 
 ---

--- a/src/slipbox_mcp/server/descriptions.py
+++ b/src/slipbox_mcp/server/descriptions.py
@@ -11,7 +11,11 @@ Re-run that build after editing a template so the skills don't drift.
 Note/link/search tool descriptions live as docstrings on the function
 bodies in server/tools/{note_tools,link_tools,search_tools}.py — those
 docstrings ARE the description the LLM sees, so this file deliberately
-does not duplicate them.
+does not duplicate them. The one exception is SERVER_INSTRUCTIONS below,
+which intentionally paraphrases note/link semantics into a single
+condensed operating guide shipped to every client on connect (clients
+may never fetch per-tool docstrings). When the two disagree, the tool
+docstrings are authoritative.
 """
 
 # ---------------------------------------------------------------------------

--- a/src/slipbox_mcp/server/descriptions.py
+++ b/src/slipbox_mcp/server/descriptions.py
@@ -15,6 +15,75 @@ does not duplicate them.
 """
 
 # ---------------------------------------------------------------------------
+# Server instructions (passed to FastMCP(instructions=...))
+# ---------------------------------------------------------------------------
+#
+# Shipped to every connecting client during MCP initialize, so the operating
+# guidance travels with the server and can never drift against a user's pasted
+# copy. This deliberately covers only *how to use the tools well* (note types,
+# link semantics, quality standards, workflows). Autonomy/initiative directives
+# — auto-capturing without asking, proactively raising maintenance at session
+# start — are NOT here: a server should not assert those on every client. They
+# remain an opt-in the user adds to their own system prompt (docs/SYSTEM_PROMPT.md).
+
+SERVER_INSTRUCTIONS = """\
+This server manages a Zettelkasten knowledge system. Prioritize knowledge
+emergence — meaningful connections that reveal insight — over plain storage.
+Before creating a note, search first (slipbox_search_notes) to avoid duplicates
+and find connection points.
+
+Note types:
+- fleeting: quick, unprocessed capture — temporary, to be refined or discarded
+- literature: an idea from a specific source, in the user's words, with citation
+- permanent: a fully formulated, standalone insight — the core unit
+- structure: organizes and synthesizes a cluster of related permanent notes
+- hub: entry point into a broad area; links to structure and key permanent notes
+
+Default to `permanent`. Use `fleeting` when an idea needs more thought. Create
+`structure` and `hub` notes intentionally, not automatically.
+
+Note quality:
+- Atomicity: one idea per note. If you write "also" or "another point", that's a
+  second note.
+- Verbatim by default: when the user hands you explicit text to save, store it
+  exactly as written. Author or refine only when explicitly asked, and show a
+  draft in chat before writing substantial refinements.
+- Voice: when you compose a note, write in the user's voice as a standalone
+  insight, not a summary.
+- Length: a permanent note typically runs 3-7 paragraphs. Match the length of
+  what the user gave you; don't pad.
+- Titles: the idea in brief; should make sense without reading the note.
+- Tags: 2-5 specific tags. Prefer existing tags when they fit.
+
+Link types (choose the most specific; use bidirectional=true for important ones):
+- reference: generic "see also" connection
+- extends: this note builds on that one
+- refines: this note clarifies or improves that one
+- contradicts: this note presents an opposing view
+- questions: this note raises questions about that one
+- supports: this note provides evidence for that one
+- related: loose thematic connection
+
+Structure notes: create one when 7-15 notes cluster around a concept without one.
+It should organize members into sections, synthesize what they reveal together,
+name tensions and open questions, and link bidirectionally to each member. Use
+slipbox_get_cluster_report to find clusters needing structure notes.
+
+Workflow patterns:
+- New information: search for existing coverage, create if novel, link immediately.
+- Exploring a topic: search, find central notes, follow links, then
+  slipbox_find_similar_notes to surface unexpected connections.
+- Batch processing: extract 5-10 atomic ideas first, search each, create the
+  novel ones, then link the batch to each other and to existing knowledge.
+- Maintenance: integrate orphans, find emergent clusters, formalize them into
+  structure notes.
+
+Workflow prompts (knowledge_creation, knowledge_creation_batch,
+knowledge_exploration, knowledge_synthesis, analyze_note, cluster_maintenance)
+package these steps — invoke them rather than reciting the steps yourself.\
+"""
+
+# ---------------------------------------------------------------------------
 # Cluster tools (wired in via cluster_tools.py)
 # ---------------------------------------------------------------------------
 

--- a/src/slipbox_mcp/server/mcp_server.py
+++ b/src/slipbox_mcp/server/mcp_server.py
@@ -8,6 +8,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import ValidationError
 
 from slipbox_mcp.config import config
+from slipbox_mcp.server.descriptions import SERVER_INSTRUCTIONS
 from slipbox_mcp.services.cluster_service import ClusterService
 from slipbox_mcp.services.search_service import SearchService
 from slipbox_mcp.services.zettel_service import ZettelService
@@ -19,7 +20,7 @@ class ZettelkastenMcpServer:
     """MCP server for Zettelkasten."""
 
     def __init__(self):
-        self.mcp = FastMCP(config.server_name)
+        self.mcp = FastMCP(config.server_name, instructions=SERVER_INSTRUCTIONS)
         self.zettel_service = ZettelService()
         self.search_service = SearchService(self.zettel_service)
         self.cluster_service = ClusterService(self.zettel_service)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -52,7 +52,10 @@ class MockServerBase:
                 return_value=self.mock_cluster_service,
             ),
         ]
-        for p in self._patchers:
+        # _patchers[0] patches FastMCP; keep its mock so tests can assert how
+        # the server constructed it (e.g. that instructions= was passed).
+        self.mock_fastmcp = self._patchers[0].start()
+        for p in self._patchers[1:]:
             p.start()
 
         self.server = ZettelkastenMcpServer()
@@ -79,6 +82,20 @@ class TestServerInitialization(MockServerBase):
 
     def test_server_is_initialized(self):
         assert self.server is not None, "Server should be constructed"
+
+    def test_server_constructed_with_instructions(self):
+        """FastMCP must receive SERVER_INSTRUCTIONS so the operating guidance
+        ships with the server and can't drift against a stale pasted copy.
+
+        Identity check, not content: this guards the wiring contract without
+        churning when the instructions prose is edited.
+        """
+        from slipbox_mcp.server.descriptions import SERVER_INSTRUCTIONS
+
+        assert (
+            self.mock_fastmcp.call_args.kwargs.get("instructions")
+            is SERVER_INSTRUCTIONS
+        ), "FastMCP must be constructed with instructions=SERVER_INSTRUCTIONS"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Splits the slipbox operating guidance into two clearly-labeled layers and documents the relationship in the README.

The server now ships its tool-usage baseline automatically via FastMCP `instructions` (the `SERVER_INSTRUCTIONS` constant), so it travels with the code and can't drift against a stale copy a user pasted. `docs/SYSTEM_PROMPT.md` is reframed as the opt-in autonomy layer on top — auto-capture and proactive maintenance — that a server shouldn't assert on every connecting client.

### Changes

- **README**: link the Zettelkasten intro to the shipped server instructions; clarify in "Recommended System Prompt" that the baseline ships automatically and `SYSTEM_PROMPT.md` is the opt-in layer (dropping the search-before-create bullet the baseline already covers).
- **docs/SYSTEM_PROMPT.md**: add an experimental, clearly-caveated section on using the slipbox as agent cross-session self-memory; minor em-dash style fix in the intro.

### Notes

- Docs-only change; no code paths touched.
- The `refactor: ship operating guidance via server instructions` commit (already on the branch) is the substantive wiring; this PR layers the documentation on top.
