### PR TITLE
docs: README docs index, agent-memory, and prose de-slop

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Python 3.10+ | macOS or Linux
 
 ## Walkthrough
 
-[![Watch the Slipbox walkthrough](https://cdn.loom.com/sessions/thumbnails/0eedecce86bc4eaeb57278ee4b79a259-with-play.gif)](https://www.loom.com/share/0eedecce86bc4eaeb57278ee4b79a259)
+[![Watch the Slipbox walkthrough](https://cdn.loom.com/sessions/thumbnails/0eedecce86bc4eaeb57278ee4b79a259-25a1ee822d272879-full-play.gif)](https://www.loom.com/share/0eedecce86bc4eaeb57278ee4b79a259)
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Built and tested with Claude. Works with any MCP client (Claude Desktop, Claude 
 
 Python 3.10+ | macOS or Linux
 
-![Direct idea capture — your raw thinking in, a formatted atomic note with tags and links out](assets/recordings/04-idea-capture.gif)
+![Direct idea capture: your raw thinking in, a formatted atomic note with tags and links out](assets/recordings/04-idea-capture.gif)
 
 ## Walkthrough
 
@@ -36,7 +36,7 @@ pipx install slipbox-mcp
 uv tool install slipbox-mcp
 ```
 
-This puts a `slipbox-mcp` launcher on your PATH (in `~/.local/bin`). That single command is the whole MCP server — no clone, no `PYTHONPATH`, no hardcoded venv Python path. Everything below uses it. To try it without installing at all, `uvx slipbox-mcp` runs the server in a throwaway environment.
+This puts a `slipbox-mcp` launcher on your PATH (in `~/.local/bin`). That single command is the whole MCP server: no clone, no `PYTHONPATH`, no hardcoded venv Python path. Everything below uses it. To try it without installing at all, `uvx slipbox-mcp` runs the server in a throwaway environment.
 
 (Working on Slipbox itself? See [Development](#development) for the clone + editable-install setup.)
 
@@ -45,7 +45,7 @@ This puts a `slipbox-mcp` launcher on your PATH (in `~/.local/bin`). That single
 One variable, `SLIPBOX_BASE_DIR`, configures everything: notes land in `<base>/data/notes` and the SQLite index in `<base>/data/db/zettelkasten.db`. The server creates these on first run.
 
 ```bash
-# Example — use any absolute path you like
+# Example: use any absolute path you like
 /Users/yourname/.local/share/mcp/slipbox
 ```
 
@@ -53,7 +53,7 @@ One variable, `SLIPBOX_BASE_DIR`, configures everything: notes land in `<base>/d
 
 ### 3. Connect to Your MCP Client
 
-**Claude Code** — one command, no file editing:
+**Claude Code** (one command, no file editing):
 
 ```bash
 claude mcp add slipbox \
@@ -61,10 +61,10 @@ claude mcp add slipbox \
   -- slipbox-mcp
 ```
 
-**Claude Desktop** — edit the config file:
+**Claude Desktop** (edit the config file):
 
-- **macOS** — `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Linux** — `~/.config/claude/claude_desktop_config.json`
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Linux**: `~/.config/claude/claude_desktop_config.json`
 
 ```json
 {
@@ -115,7 +115,7 @@ Ask your agent:
 The hero above is the core loop. Here's the rest of what the agent does.
 
 <details>
-<summary><b>See Slipbox in action</b> — eleven more demos, plus the Obsidian semantic-graph integration</summary>
+<summary><b>See Slipbox in action</b>: eleven more demos, plus the Obsidian semantic-graph integration</summary>
 
 ### Proactive Maintenance
 
@@ -189,11 +189,11 @@ Notes are plain markdown. Open the vault in Obsidian and everything works -- ren
 
 For a graph that renders the _typed_ links in color (supports, extends, refines, ...) rather than Obsidian's untyped built-in graph, install the companion plugin **[Slipbox Semantic Graph](https://github.com/jamesfishwick/obsidian-slipbox-graph)** -- a force-directed view with human-readable titles and color-coded semantic link types. Install it manually from the [0.1.0 release](https://github.com/jamesfishwick/obsidian-slipbox-graph/releases/tag/0.1.0): copy `main.js`, `manifest.json`, and `styles.css` into `<vault>/.obsidian/plugins/slipbox-graph/`, then enable it in Settings → Community plugins. (Once it's accepted into the official directory, you'll also be able to install it via Settings → Community plugins → Browse → search "Slipbox Semantic Graph".) It reads the same frontmatter `id` and `## Links` section the server writes, so no extra configuration is needed. Open the view with the **Open semantic graph** command (Command Palette) or the **git-fork** ribbon icon.
 
-![Slipbox Semantic Graph — the full vault, with typed links color-coded by relationship](assets/screenshots/obsidian-graph.png)
+![Slipbox Semantic Graph: the full vault, with typed links color-coded by relationship](assets/screenshots/obsidian-graph.png)
 
-The legend across the top maps each color to a link type (extends, refines, supports, contradicts, questions, related). Focus a structure note and its constellation comes into view — here, `Contract Testing Knowledge Map` with its member notes orbiting it:
+The legend across the top maps each color to a link type (extends, refines, supports, contradicts, questions, related). Focus a structure note and its constellation comes into view. Here, `Contract Testing Knowledge Map` with its member notes orbiting it:
 
-![Slipbox Semantic Graph — a structure note and its member-note constellation](assets/screenshots/obsidian-graph-structure-note.png)
+![Slipbox Semantic Graph: a structure note and its member-note constellation](assets/screenshots/obsidian-graph-structure-note.png)
 
 </details>
 
@@ -255,7 +255,7 @@ source .venv/bin/activate
 python scripts/watch_notes.py
 ```
 
-Edit a note file—you should see "rebuilding index..." in the watcher output.
+Edit a note file. You should see "rebuilding index..." in the watcher output.
 
 ### Check Status
 
@@ -351,8 +351,8 @@ MCP prompts are reusable workflow templates that encode the Zettelkasten method 
 
 Each workflow ships two ways:
 
-- **MCP prompts** — served by the running server.
-- **Skills** — standalone bundles (`skills/<name>/`) that run the same workflow and add natural-language triggering.
+- **MCP prompts**: served by the running server.
+- **Skills**: standalone bundles (`skills/<name>/`) that run the same workflow and add natural-language triggering.
 
 Five of the six skills are generated from the same `PROMPT_*` templates the server uses (`src/slipbox_mcp/server/descriptions.py`), and CI fails if the committed `skills/` drift from those templates. The sixth, `cluster-maintenance`, is authored directly in `scripts/build_skills.py` because its MCP prompt is a runtime-rendered status message rather than a reusable workflow.
 
@@ -369,7 +369,7 @@ Five of the six skills are generated from the same `PROMPT_*` templates the serv
 
 (Installed skills also expose their own slash commands by directory name, e.g. `/slipbox-analyze-note`.)
 
-**Natural language** works once the matching skill is installed — just describe what you want:
+**Natural language** works once the matching skill is installed. Just describe what you want:
 
 ```text
 Analyze this note for my slipbox: [paste note]
@@ -379,11 +379,11 @@ Add this to my slipbox: [paste article]
 Synthesize my notes on attention and memory.
 ```
 
-Prose triggering depends on the skill being installed and your phrasing matching its description; fall back to the slash command if it doesn't fire. Asking the model to "use the analyze_note prompt" by name does **not** work — the model can't invoke an MCP prompt by name. Use a slash command, or let a skill trigger from natural language.
+Prose triggering depends on the skill being installed and your phrasing matching its description; fall back to the slash command if it doesn't fire. Asking the model to "use the analyze_note prompt" by name does **not** work. The model can't invoke an MCP prompt by name. Use a slash command, or let a skill trigger from natural language.
 
 ### Installing Skills
 
-**Claude Code** discovers skills from `.claude/skills/` (per project) or `~/.claude/skills/` (global), not from a bare top-level `skills/`. Symlink or copy the ones you want into a discovery path — e.g. for this project:
+**Claude Code** discovers skills from `.claude/skills/` (per project) or `~/.claude/skills/` (global), not from a bare top-level `skills/`. Symlink or copy the ones you want into a discovery path (e.g. for this project):
 
 ```bash
 mkdir -p .claude/skills
@@ -427,7 +427,7 @@ After editing a prompt template in `descriptions.py`, re-run the build to regene
 | `structure`  | Maps organizing 7-15 related notes on a specific topic                                           |
 | `hub`        | Domain overview linking to structure notes; entry point for navigating a broad area of knowledge |
 
-**Structure vs. Hub:** A structure note organizes a cluster of permanent notes around a single topic — it is a curated map one level above the notes themselves. A hub note operates one level higher still: it links to structure notes (and occasionally key permanent notes) across an entire knowledge domain. Where a structure note answers "what do I know about X?", a hub note answers "how is my knowledge of this whole domain organized?" Most Zettelkastens need only a handful of hub notes.
+**Structure vs. Hub:** A structure note organizes a cluster of permanent notes around a single topic. It is a curated map one level above the notes themselves. A hub note operates one level higher still: it links to structure notes (and occasionally key permanent notes) across an entire knowledge domain. Where a structure note answers "what do I know about X?", a hub note answers "how is my knowledge of this whole domain organized?" Most Zettelkastens need only a handful of hub notes.
 
 ---
 
@@ -498,7 +498,7 @@ If your notes directory ends up at `./~/...` relative to CWD, you used `~` in th
 
 ### `slipbox_list_notes_by_date` returns empty results
 
-If `start_date` is later than `end_date`, no notes match and an empty result is returned — this is expected behavior, not an error.
+If `start_date` is later than `end_date`, no notes match and an empty result is returned. This is expected behavior, not an error.
 
 ### Database out of sync
 
@@ -626,9 +626,9 @@ ruff check src/ evals/
 | `LLM Evals` | Opt-in (label or manual) | Self-hosted   | 28 LLM evals via claude CLI                              |
 | `Release`   | Push to `main`           | GitHub-hosted | release-please PR; on its merge, build + publish to PyPI |
 
-The LLM eval suite is expensive (~$3-5, ~10 min) and self-hosted, so it **never runs automatically** — a path-based trigger can't distinguish a real prompt change from a cosmetic reformat. Run it deliberately when you change prompt or tool-description semantics:
+The LLM eval suite is expensive (~$3-5, ~10 min) and self-hosted, so it **never runs automatically**. A path-based trigger can't distinguish a real prompt change from a cosmetic reformat. Run it deliberately when you change prompt or tool-description semantics:
 
-- **Add the `run-llm-evals` label** to the PR — it runs, and re-runs on each push while the label is present.
+- **Add the `run-llm-evals` label** to the PR. It runs, and re-runs on each push while the label is present.
 - **Or trigger it manually** from the Actions tab (`workflow_dispatch`).
 - **Or run it locally** without the runner: `pytest evals/llm/ -v`.
 
@@ -638,7 +638,7 @@ Without a label or manual dispatch, the job is skipped (no runner allocated, no 
 
 **If you don't want a self-hosted runner:** remove `.github/workflows/llm-evals.yml` and run `pytest evals/llm/ -v` locally before merging prompt changes.
 
-**If you want LLM evals on every PR automatically:** add a `pull_request` trigger with the relevant `paths:` filter and drop the label gate in the job's `if:` — but expect incidental triggers from formatting-only edits.
+**If you want LLM evals on every PR automatically:** add a `pull_request` trigger with the relevant `paths:` filter and drop the label gate in the job's `if:`. But expect incidental triggers from formatting-only edits.
 
 **To change the default eval model:** Set `EVAL_MODEL` in your environment or in the workflow file. Default is `haiku` for speed/cost.
 
@@ -660,9 +660,9 @@ nohup ./run.sh &
 
 ### Releasing to PyPI
 
-Releases are automated. The `Release` workflow (`.github/workflows/release.yml`) runs [release-please](https://github.com/googleapis/release-please) on every push to `main` and publishes via PyPI [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) — OIDC, so no API token is stored in repo secrets.
+Releases are automated. The `Release` workflow (`.github/workflows/release.yml`) runs [release-please](https://github.com/googleapis/release-please) on every push to `main` and publishes via PyPI [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC, so no API token is stored in repo secrets).
 
-**The flow — you never hand-edit a version or push a tag:**
+**The flow (you never hand-edit a version or push a tag):**
 
 1. Land changes on `main` with [Conventional Commit](https://www.conventionalcommits.org/) messages (`feat:` → minor bump, `fix:` → patch, `feat!:`/`BREAKING CHANGE:` → major). The repo's commit hooks already enforce this shape.
 2. release-please keeps a standing **"release PR"** open, accumulating the next version bump (in `src/slipbox_mcp/__init__.py`) and the `CHANGELOG.md` entries derived from those commits.
@@ -670,7 +670,7 @@ Releases are automated. The `Release` workflow (`.github/workflows/release.yml`)
 
 So cutting a release is one click: merge the bot's PR. Nothing else.
 
-**Commit types decide the version — so type accurately.** The bump is computed mechanically from the Conventional Commit prefixes since the last release, not from the size of the change. Reserve `feat:`/`fix:` for changes to the **shipped package**; use the non-releasing types for everything else:
+**Commit types decide the version. So type accurately.** The bump is computed mechanically from the Conventional Commit prefixes since the last release, not from the size of the change. Reserve `feat:`/`fix:` for changes to the **shipped package**; use the non-releasing types for everything else:
 
 | Prefix                                              | Version effect        | Use for                                             |
 | --------------------------------------------------- | --------------------- | --------------------------------------------------- |
@@ -679,14 +679,14 @@ So cutting a release is one click: merge the bot's PR. Nothing else.
 | `feat!:` / `BREAKING CHANGE:`                       | major (1.3.0 → 2.0.0) | backwards-incompatible change                       |
 | `docs:` `ci:` `build:` `chore:` `test:` `refactor:` | **none**              | docs, tooling, CI, packaging, internal-only changes |
 
-A batch of only non-releasing commits produces **no release PR at all**. The squash-merge title is the commit release-please reads, so the PR title's prefix is what counts — label it for what the _package_ gains, not for the effort spent.
+A batch of only non-releasing commits produces **no release PR at all**. The squash-merge title is the commit release-please reads, so the PR title's prefix is what counts. Label it for what the _package_ gains, not for the effort spent.
 
 **One-time setup** (already done for this repo, documented for forks):
 
-1. On PyPI, register a [pending trusted publisher](https://pypi.org/manage/account/publishing/) for project `slipbox-mcp` — **Owner:** `jamesfishwick` · **Repository:** `slipbox-mcp` · **Workflow:** `release.yml` · **Environment:** `release`. All four must match exactly.
+1. On PyPI, register a [pending trusted publisher](https://pypi.org/manage/account/publishing/) for project `slipbox-mcp`: **Owner:** `jamesfishwick` · **Repository:** `slipbox-mcp` · **Workflow:** `release.yml` · **Environment:** `release`. All four must match exactly.
 2. In GitHub, create an environment named `release` (Settings → Environments). If you restrict its deployment refs, add a **tag** rule `v*` (a _branch_ rule of the same name will not match the tag).
 
-> The version is defined once, in `src/slipbox_mcp/__init__.py` (release-please bumps it; the `# x-release-please-version` marker tells it which line). `pyproject.toml` (`dynamic = ["version"]`) and the server's `server_version` both read from it, so there is nothing to keep in sync — and the tag release-please cuts always matches the package version by construction.
+> The version is defined once, in `src/slipbox_mcp/__init__.py` (release-please bumps it; the `# x-release-please-version` marker tells it which line). `pyproject.toml` (`dynamic = ["version"]`) and the server's `server_version` both read from it, so there is nothing to keep in sync; the tag release-please cuts always matches the package version by construction.
 
 To rehearse a build without publishing, run it by hand: `python -m build && twine check dist/*` (and `twine upload --repository testpypi dist/*` with a TestPyPI token to dry-run the upload).
 

--- a/README.md
+++ b/README.md
@@ -720,6 +720,25 @@ Install: `pipx install --editable .` (adds `slipbox` to your PATH)
 
 ---
 
+## Experimental: Slipbox as agent memory
+
+An untested hypothesis, not a recommended setup. Everything above helps an agent manage _your_ knowledge. This inverts it: the agent uses a slipbox as its own persistent memory across sessions, in place of native memory or a rules file.
+
+The model has no memory between sessions, so the slipbox is the only channel one session leaves for the next. It writes briefings for a cold successor (a failure and why, a recurring constraint, a correction, a hard-won fact), tags them `agent-memory`, and searches that tag before acting. The bet is that a _connected_ memory beats a flat rules file, because you retrieve it by traversal.
+
+Three things to know first: namespace isolation is a tag convention, not enforced, so run it against a separate slipbox instance; "memory" is a misnomer, since nothing persists but the notes themselves; and the growth discipline is the unproven part, so expect sprawl on the first run. Full write-up and caveats: [Slipbox as Agent Self-Memory](docs/SYSTEM_PROMPT.md#experimental-slipbox-as-agent-self-memory).
+
+## Documentation
+
+| Doc                                                            | What's in it                                                                                 |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [Quick Reference](docs/QUICK_REFERENCE.md)                     | Note ID format, the five note types, and a one-page cheat sheet for the method.              |
+| [Manual Zettelkasten Guide](docs/MANUAL_ZETTELKASTEN_GUIDE.md) | Running the same workflow by hand in Obsidian, no agent involved.                            |
+| [Link Format](docs/LINK_FORMAT.md)                             | How Slipbox's links map to `[[wikilinks]]` and other editors' formats.                       |
+| [Ecosystem Compatibility](docs/ECOSYSTEM_COMPATIBILITY.md)     | Which other tools can read and write the same vault.                                         |
+| [System Prompt](docs/SYSTEM_PROMPT.md)                         | The opt-in autonomy layer: auto-capture, cluster detection, and the agent-memory experiment. |
+| [Demo](demo.md)                                                | A worked session showing the tools in use.                                                   |
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, coding standards, and how to submit changes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,9 +14,15 @@ The current `slipbox_find_similar_notes` uses shared tags, common links, and con
 
 ### Cross-cluster bridge detection
 
-The current cluster tools measure how densely a cluster is linked *internally* and surface orphans, but don't scan between clusters for missing edges. The real drought in most slipboxes is at cluster boundaries -- notes articulating the same structural claim in different vocabularies (e.g. `editorial curation` in a poetry cluster and `context curation` in an AI-coding cluster) stay disconnected because they share no tags.
+The current cluster tools measure how densely a cluster is linked _internally_ and surface orphans, but don't scan between clusters for missing edges. The real drought in most slipboxes is at cluster boundaries -- notes articulating the same structural claim in different vocabularies (e.g. `editorial curation` in a poetry cluster and `context curation` in an AI-coding cluster) stay disconnected because they share no tags.
 
 A `slipbox_find_missing_bridges` operation would, for each pair of tag clusters, return candidate note pairs with no existing link, no short path in the link graph, and content-overlap above a threshold -- ranked by strength. A companion workflow prompt lets the agent run the scan during cluster maintenance, suggest a link type, and submit candidates for user approval -- matching the propose-then-confirm shape of cluster-based structure notes.
+
+### Agent-memory namespace enforcement
+
+The [agent-self-memory experiment](docs/SYSTEM_PROMPT.md#experimental-slipbox-as-agent-self-memory) has an agent use a slipbox as its own cross-session memory, fenced off by an `agent-memory` tag. Today that fence is a prose convention: nothing stops a confused agent from writing untagged notes or reading the human's. Enforcing the boundary in the server (a reserved tag namespace, or a separate memory store) is the prerequisite to running the experiment against a real vault instead of a throwaway one.
+
+A companion forcing function would address the other open risk: an over-capturing agent produces sprawl that mimics healthy branching. A structural check at write time (a per-session write budget, or a mandatory justification field) constrains it where prose asking for restraint cannot.
 
 ### Note templates
 

--- a/demo.md
+++ b/demo.md
@@ -2,7 +2,7 @@
 
 slipbox-mcp is a Model Context Protocol server that gives your AI assistant an active role in managing a Zettelkasten knowledge system. Instead of passively assisting with note-taking, the agent creates atomic notes, forms semantic links, and detects emergent knowledge clusters. It works with any MCP-compatible client.
 
-Notes are stored as plain markdown files with YAML frontmatter — readable and editable in any tool (Obsidian, Foam, Logseq, etc.). A SQLite+FTS5 database provides fast full-text search and is rebuilt from files on demand.
+Notes are stored as plain markdown files with YAML frontmatter: readable and editable in any tool (Obsidian, Foam, Logseq, etc.). A SQLite+FTS5 database provides fast full-text search and is rebuilt from files on demand.
 
 For the purposes of this demo, all responses are from Claude connected via `claude -p`. Everything runs against a real Zettelkasten -- 549 notes accumulated over months of daily use, covering software architecture, poetry, knowledge management, AI development, and whatever else caught my attention. Responses are not mocked or edited.
 
@@ -12,7 +12,6 @@ Every note is a plain markdown file with YAML frontmatter. The full schema inclu
 
 ```bash
 SLIPBOX_BASE_DIR=. slipbox export 20260312T114409277900000
-
 ```
 
 ```output
@@ -50,10 +49,9 @@ agent capability. [...]
 - extended_by [[20260312T114557128889000]] Pattern sourced directly from Harness garbage collection / doc-gardening agent
 - supported_by [[20260312T115034125616000]] Both sources converge on map + pointers structure
 - related [[20260312T120432796672000]] Both describe specialized agent ecosystems for different SDLC phases
-
 ```
 
-The **references** field stores bibliographic citations — the [text reference](https://zettelkasten.de/posts/zettelkasten-building-blocks/#crossing-the-boundary-with-text-references) that crosses the boundary between the internal knowledge graph and external sources. The **links** section uses typed relationships (`supports`, `extended_by`, `supported_by`, `related`) to connect notes within the graph.
+The **references** field stores bibliographic citations: the [text reference](https://zettelkasten.de/posts/zettelkasten-building-blocks/#crossing-the-boundary-with-text-references) that crosses the boundary between the internal knowledge graph and external sources. The **links** section uses typed relationships (`supports`, `extended_by`, `supported_by`, `related`) to connect notes within the graph.
 
 ## Browsing Notes
 
@@ -75,7 +73,6 @@ Since notes are plain markdown with `[[wiki-links]]`, they work in any editor --
 
 ```bash
 SLIPBOX_BASE_DIR=. slipbox status
-
 ```
 
 ```output
@@ -84,7 +81,6 @@ Tags: 1581
 Orphans: 63
 Pending clusters: 5
 Report age: 1.9h
-
 ```
 
 ## Full-Text Search (FTS5)
@@ -96,15 +92,15 @@ The SQLite FTS5 index enables BM25-ranked full-text search. Results are ordered 
 <details>
 <summary>Claude's response</summary>
 
-| # | ID            | Title                                                   | Tags                                    |
-|---|---------------|---------------------------------------------------------|-----------------------------------------|
-| 1 | 20260225T1719 | zettelkasten-mcp: agentic knowledge management as a...  | mcp, zettelkasten, knowledge-management |
-| 2 | 20260225T1718 | qmd and zettelkasten-mcp solve different problems i...  | mcp, search, tool-comparison            |
-| 3 | 20250630T2133 | Bridge Pattern for Dual Knowledge Systems               | workflow, zettelkasten, knowledge-mgmt  |
-| 4 | 20250630T2135 | Recommendation: Hybrid Knowledge Architecture           | recommendation, architecture-decision, knowledge-strategy |
-| 5 | 20250630T2134 | Daily Workflow with Dual Knowledge Systems               | workflow, knowledge-management, daily-practice |
-| 6 | 20250630T2133 | Selective Migration Criteria for Archive Notes           | zettelkasten, knowledge-management, migration |
-| 7 | 20260327T1420 | The Cost of Unlinked Knowledge                          | zettelkasten, knowledge-management      |
+| # | ID            | Title                                                  | Tags                                                      |
+| - | ------------- | ------------------------------------------------------ | --------------------------------------------------------- |
+| 1 | 20260225T1719 | zettelkasten-mcp: agentic knowledge management as a... | mcp, zettelkasten, knowledge-management                   |
+| 2 | 20260225T1718 | qmd and zettelkasten-mcp solve different problems i... | mcp, search, tool-comparison                              |
+| 3 | 20250630T2133 | Bridge Pattern for Dual Knowledge Systems              | workflow, zettelkasten, knowledge-mgmt                    |
+| 4 | 20250630T2135 | Recommendation: Hybrid Knowledge Architecture          | recommendation, architecture-decision, knowledge-strategy |
+| 5 | 20250630T2134 | Daily Workflow with Dual Knowledge Systems             | workflow, knowledge-management, daily-practice            |
+| 6 | 20250630T2133 | Selective Migration Criteria for Archive Notes         | zettelkasten, knowledge-management, migration             |
+| 7 | 20260327T1420 | The Cost of Unlinked Knowledge                         | zettelkasten, knowledge-management                        |
 
 7 results returned (fewer than 8 requested).
 
@@ -112,57 +108,57 @@ The SQLite FTS5 index enables BM25-ranked full-text search. Results are ordered 
 
 ## Graph Analysis: Central Notes
 
-Central notes have the most inbound and outbound links — they are the structural anchors of the knowledge graph:
+Central notes have the most inbound and outbound links. They are the structural anchors of the knowledge graph:
 
 > Find the 10 most connected notes in my Zettelkasten.
 
 <details>
 <summary>Claude's response</summary>
 
-| Rank | ID | Title | Links |
-|-----:|--------------|-------|------:|
-| 1 | `20260327T1421` | Contract Testing Knowledge Map | 52 |
-| 2 | `20250625T2018` | Software Craft Evolution in AI-Assisted Development | 30 |
-| 3 | `20250619T1326` | Contract Enforcement in Multi-Team API Development | 28 |
-| 4 | `20251217T1724` | Poetry Revision Principles | 26 |
-| 5 | `20260227T1302` | Allison Parrish: Computational Poetry and Its Tensions | 24 |
-| 6 | `20250619T1000` | Contract Testing with OpenAPI Specifications | 21 |
-| 7 | `20250619T1000` | OpenAPI Contract Testing Tool Ecosystem | 20 |
-| 8 | `20251217T1725` | Consciousness and Near-Death Experience Studies | 20 |
-| 9 | `20250612T2118` | Software Engineering as Craft Mastery | 19 |
-| 10 | `20260111T2111` | AI as Hauntological Engine: Industrializing Cultural Recursion | 19 |
+| Rank | ID              | Title                                                          | Links |
+| ---: | --------------- | -------------------------------------------------------------- | ----: |
+|    1 | `20260327T1421` | Contract Testing Knowledge Map                                 |    52 |
+|    2 | `20250625T2018` | Software Craft Evolution in AI-Assisted Development            |    30 |
+|    3 | `20250619T1326` | Contract Enforcement in Multi-Team API Development             |    28 |
+|    4 | `20251217T1724` | Poetry Revision Principles                                     |    26 |
+|    5 | `20260227T1302` | Allison Parrish: Computational Poetry and Its Tensions         |    24 |
+|    6 | `20250619T1000` | Contract Testing with OpenAPI Specifications                   |    21 |
+|    7 | `20250619T1000` | OpenAPI Contract Testing Tool Ecosystem                        |    20 |
+|    8 | `20251217T1725` | Consciousness and Near-Death Experience Studies                |    20 |
+|    9 | `20250612T2118` | Software Engineering as Craft Mastery                          |    19 |
+|   10 | `20260111T2111` | AI as Hauntological Engine: Industrializing Cultural Recursion |    19 |
 
 </details>
 
 ## Graph Analysis: Orphaned Notes
 
-Notes with no links are candidates for connection — or deletion:
+Notes with no links are candidates for connection, or deletion:
 
-> Find all my orphaned notes — the ones with no connections to anything else.
+> Find all my orphaned notes, the ones with no connections to anything else.
 
 <details>
 <summary>Claude's response</summary>
 
 **61 orphaned notes** total. First 10:
 
-| # | ID | Title |
-|---|---|---|
-| 1 | `20250910T135618200530000` | Multi-Head Attention: Full Input Projection Not Slicing |
-| 2 | `20251022T162907314970000` | Why Aliasing rm to trash Breaks Scripts |
-| 3 | `20251228T213740782043000` | Elemental Spirits and Greek Nymph Taxonomy |
-| 4 | `20250805T090954856379000` | Sound Contradictions in Poetry - When They Work |
-| 5 | `20250904T213124507346000` | Cardinal Parental Behavior and Social Learning |
-| 6 | `20250723T102948408741000` | The Three-Way Labor Arbitrage Fantasy |
-| 7 | `20250805T220805664533000` | "Fly" as Flee in Poetry - Double Meaning Power |
-| 8 | `20250903T114120275588000` | Environment Promotion Gates for API Changes |
-| 9 | `20250707T210125380679000` | Evolution of Prompt Engineering Techniques and Cargo Cult Patterns |
-| 10 | `20250617T220555314774000` | Domain Registration vs DNS Hosting Confusion |
+| #  | ID                         | Title                                                              |
+| -- | -------------------------- | ------------------------------------------------------------------ |
+| 1  | `20250910T135618200530000` | Multi-Head Attention: Full Input Projection Not Slicing            |
+| 2  | `20251022T162907314970000` | Why Aliasing rm to trash Breaks Scripts                            |
+| 3  | `20251228T213740782043000` | Elemental Spirits and Greek Nymph Taxonomy                         |
+| 4  | `20250805T090954856379000` | Sound Contradictions in Poetry - When They Work                    |
+| 5  | `20250904T213124507346000` | Cardinal Parental Behavior and Social Learning                     |
+| 6  | `20250723T102948408741000` | The Three-Way Labor Arbitrage Fantasy                              |
+| 7  | `20250805T220805664533000` | "Fly" as Flee in Poetry - Double Meaning Power                     |
+| 8  | `20250903T114120275588000` | Environment Promotion Gates for API Changes                        |
+| 9  | `20250707T210125380679000` | Evolution of Prompt Engineering Techniques and Cargo Cult Patterns |
+| 10 | `20250617T220555314774000` | Domain Registration vs DNS Hosting Confusion                       |
 
 </details>
 
 ## Cluster Detection
 
-The cluster detector finds groups of co-occurring tags that lack a structure note to organize them. Clusters are scored by size, orphan ratio, link density, and recency — high scores are strong candidates for Claude to synthesize into structure notes:
+The cluster detector finds groups of co-occurring tags that lack a structure note to organize them. Clusters are scored by size, orphan ratio, link density, and recency. High scores are strong candidates for Claude to synthesize into structure notes:
 
 > Run a cluster analysis and show me the top clusters that need structure notes.
 
@@ -186,14 +182,11 @@ Cluster Report -- 2026-04-12
 
 3  Intentionality Knowledge Map      0.511     6       1     agency, hartman, intentionality,
                                                              mac-low, parrish, politics
-
 ```
 
 Only 3 clusters scored above the default 0.5 threshold (out of 6 total needing structure notes). The remaining 3 fell below and were filtered out.
 
-`★ Insight ─────────────────────────────────────`
-**Cluster scoring** -- The scoring algorithm favors clusters that are "ripe" for structuring: 7-15 notes is the sweet spot (enough material, not yet unwieldy), high orphan ratios signal urgency (notes floating without connections), and low internal link density means a structure note would add the most value. Cluster #1 ranks highest despite having fewer notes than #2 because its orphan ratio (2/7 = 29%) is significantly higher, indicating more unconnected material needing a home.
-`─────────────────────────────────────────────────`
+`★ Insight ─────────────────────────────────────` **Cluster scoring** -- The scoring algorithm favors clusters that are "ripe" for structuring: 7-15 notes is the sweet spot (enough material, not yet unwieldy), high orphan ratios signal urgency (notes floating without connections), and low internal link density means a structure note would add the most value. Cluster #1 ranks highest despite having fewer notes than #2 because its orphan ratio (2/7 = 29%) is significantly higher, indicating more unconnected material needing a home. `─────────────────────────────────────────────────`
 
 Want me to lower `min_score` to see all 6 clusters, or drill into any of these with `include_notes: true`?
 
@@ -208,28 +201,28 @@ grep -rh 'def slipbox_' src/slipbox_mcp/server/tools/ | sed 's/.*def //' | sed '
 ```
 
 ```output
-  slipbox_create_link
-  slipbox_create_note
-  slipbox_create_structure_from_cluster
-  slipbox_delete_link
-  slipbox_delete_note
-  slipbox_dismiss_cluster
-  slipbox_find_central_notes
-  slipbox_find_orphaned_notes
-  slipbox_find_similar_notes
-  slipbox_get_all_tags
-  slipbox_get_cluster_report
-  slipbox_get_linked_notes
-  slipbox_get_note
-  slipbox_list_notes_by_date
-  slipbox_rebuild_index
-  slipbox_refresh_clusters
-  slipbox_remove_link
-  slipbox_search_notes
-  slipbox_update_note
+slipbox_create_link
+slipbox_create_note
+slipbox_create_structure_from_cluster
+slipbox_delete_link
+slipbox_delete_note
+slipbox_dismiss_cluster
+slipbox_find_central_notes
+slipbox_find_orphaned_notes
+slipbox_find_similar_notes
+slipbox_get_all_tags
+slipbox_get_cluster_report
+slipbox_get_linked_notes
+slipbox_get_note
+slipbox_list_notes_by_date
+slipbox_rebuild_index
+slipbox_refresh_clusters
+slipbox_remove_link
+slipbox_search_notes
+slipbox_update_note
 ```
 
-Seven semantic link types connect notes: **reference**, **extends**, **refines**, **contradicts**, **questions**, **supports**, **related**. These typed relationships let Claude navigate the knowledge graph purposefully — not just by keyword.
+Seven semantic link types connect notes: **reference**, **extends**, **refines**, **contradicts**, **questions**, **supports**, **related**. These typed relationships let Claude navigate the knowledge graph purposefully, not just by keyword.
 
 All notes are plain markdown files with YAML frontmatter, readable and editable in Obsidian, Foam, Logseq, or any text editor. The SQLite+FTS5 index is always rebuildable from the files.
 
@@ -247,10 +240,9 @@ This section covers everything worth showing when demoing slipbox to someone. Ea
 
 ```text
 Use the slipbox://maintenance-status resource and tell me if there's anything that needs attention.
-
 ```
 
-**What it shows:** The MCP resource endpoint returns pending cluster data without the user asking. Explain that in a well-configured Claude Desktop setup, this could surface automatically at session start — Claude acting as a proactive knowledge manager, not just a passive assistant.
+**What it shows:** The MCP resource endpoint returns pending cluster data without the user asking. Explain that in a well-configured Claude Desktop setup, this could surface automatically at session start: Claude acting as a proactive knowledge manager, not just a passive assistant.
 
 <details>
 <summary>Claude's response</summary>
@@ -259,18 +251,16 @@ Here's your maintenance status:
 
 Slipbox: 549 notes, 63 orphans, 6 clusters pending structure notes
 
-| # | Cluster | Score | Notes | Orphans | Tags |
-|---|---------|-------|-------|---------|------|
-| 1 | **Prompt Engineering** | 0.678 | 7 | 2 | ai-prompting, evaluation, prompt-engineering, testing |
-| 2 | **Data Architecture** | 0.557 | 8 | 1 | atscale, data-architecture, databricks, semantic-layer |
-| 3 | **Intentionality** | 0.511 | 6 | 1 | agency, hartman, intentionality, mac-low, parrish, politics |
-| 4 | **Case Study (GraphQL/Healthcare)** | 0.481 | 7 | 1 | case-study, graphql, healthcare, rest-api |
-| 5 | **Cultural Theory (Hauntology)** | 0.479 | 8 | 0 | cultural-theory, derrida, hauntology, mark-fisher, trace |
-| 6 | **Knowledge Management** | 0.436 | 6 | 0 | knowledge-management, mcp, zettelkasten |
+| # | Cluster                             | Score | Notes | Orphans | Tags                                                        |
+| - | ----------------------------------- | ----- | ----- | ------- | ----------------------------------------------------------- |
+| 1 | **Prompt Engineering**              | 0.678 | 7     | 2       | ai-prompting, evaluation, prompt-engineering, testing       |
+| 2 | **Data Architecture**               | 0.557 | 8     | 1       | atscale, data-architecture, databricks, semantic-layer      |
+| 3 | **Intentionality**                  | 0.511 | 6     | 1       | agency, hartman, intentionality, mac-low, parrish, politics |
+| 4 | **Case Study (GraphQL/Healthcare)** | 0.481 | 7     | 1       | case-study, graphql, healthcare, rest-api                   |
+| 5 | **Cultural Theory (Hauntology)**    | 0.479 | 8     | 0       | cultural-theory, derrida, hauntology, mark-fisher, trace    |
+| 6 | **Knowledge Management**            | 0.436 | 6     | 0       | knowledge-management, mcp, zettelkasten                     |
 
-`★ Insight ─────────────────────────────────────`
-The scoring favors clusters with orphaned notes and lower internal link density -- that's why **Prompt Engineering** ranks highest despite having fewer notes than **Data Architecture** or **Cultural Theory**. Orphans signal fragmentation: notes exist but aren't woven into the graph yet, so a structure note there yields the most connectivity gain per effort.
-`─────────────────────────────────────────────────`
+`★ Insight ─────────────────────────────────────` The scoring favors clusters with orphaned notes and lower internal link density -- that's why **Prompt Engineering** ranks highest despite having fewer notes than **Data Architecture** or **Cultural Theory**. Orphans signal fragmentation: notes exist but aren't woven into the graph yet, so a structure note there yields the most connectivity gain per effort. `─────────────────────────────────────────────────`
 
 **Top priority**: Clusters 1-3 are above 0.5 and have orphans -- those would benefit most from structure notes. Clusters 4-6 are lower urgency (below 0.5 or zero orphans).
 
@@ -286,30 +276,28 @@ Want me to run `/slipbox-cluster-maintenance` to start processing any of these?
 
 ```text
 Search my notes for "zettelkasten workflow" and show me the most relevant results.
-
 ```
 
 Or with tag filtering:
 
 ```text
 Search for notes tagged "poetry" and "craft" about revision.
-
 ```
 
-**What it shows:** BM25-ranked FTS5 search across 550+ notes returns in milliseconds. Point out that the results combine full-text scoring with tag filtering — not just a grep.
+**What it shows:** BM25-ranked FTS5 search across 550+ notes returns in milliseconds. Point out that the results combine full-text scoring with tag filtering, not just a grep.
 
 <details>
 <summary>Claude's response</summary>
 
-| # | ID            | Title                                                   | Tags                                    |
-|---|---------------|---------------------------------------------------------|-----------------------------------------|
-| 1 | 20260225T1719 | zettelkasten-mcp: agentic knowledge management as a...  | mcp, zettelkasten, knowledge-management |
-| 2 | 20260225T1718 | qmd and zettelkasten-mcp solve different problems i...  | mcp, search, tool-comparison            |
-| 3 | 20250630T2133 | Bridge Pattern for Dual Knowledge Systems               | workflow, zettelkasten, knowledge-mgmt  |
-| 4 | 20250630T2135 | Recommendation: Hybrid Knowledge Architecture           | recommendation, architecture-decision, knowledge-strategy |
-| 5 | 20250630T2134 | Daily Workflow with Dual Knowledge Systems               | workflow, knowledge-management, daily-practice |
-| 6 | 20250630T2133 | Selective Migration Criteria for Archive Notes           | zettelkasten, knowledge-management, migration |
-| 7 | 20260327T1420 | The Cost of Unlinked Knowledge                          | zettelkasten, knowledge-management      |
+| # | ID            | Title                                                  | Tags                                                      |
+| - | ------------- | ------------------------------------------------------ | --------------------------------------------------------- |
+| 1 | 20260225T1719 | zettelkasten-mcp: agentic knowledge management as a... | mcp, zettelkasten, knowledge-management                   |
+| 2 | 20260225T1718 | qmd and zettelkasten-mcp solve different problems i... | mcp, search, tool-comparison                              |
+| 3 | 20250630T2133 | Bridge Pattern for Dual Knowledge Systems              | workflow, zettelkasten, knowledge-mgmt                    |
+| 4 | 20250630T2135 | Recommendation: Hybrid Knowledge Architecture          | recommendation, architecture-decision, knowledge-strategy |
+| 5 | 20250630T2134 | Daily Workflow with Dual Knowledge Systems             | workflow, knowledge-management, daily-practice            |
+| 6 | 20250630T2133 | Selective Migration Criteria for Archive Notes         | zettelkasten, knowledge-management, migration             |
+| 7 | 20260327T1420 | The Cost of Unlinked Knowledge                         | zettelkasten, knowledge-management                        |
 
 7 results returned (fewer than 8 requested).
 
@@ -323,7 +311,6 @@ Search for notes tagged "poetry" and "craft" about revision.
 
 ```text
 Which notes are the most connected in my Zettelkasten? Show me the top 10.
-
 ```
 
 **What it shows:** `slipbox_find_central_notes` traverses the link graph and surfaces structural anchors. These are the notes everything else orbits. A knowledge base with no central notes is a pile of files; one with them is a network.
@@ -331,18 +318,18 @@ Which notes are the most connected in my Zettelkasten? Show me the top 10.
 <details>
 <summary>Claude's response</summary>
 
-| Rank | ID | Title | Links |
-|-----:|--------------|-------|------:|
-| 1 | `20260327T1421` | Contract Testing Knowledge Map | 52 |
-| 2 | `20250625T2018` | Software Craft Evolution in AI-Assisted Development | 30 |
-| 3 | `20250619T1326` | Contract Enforcement in Multi-Team API Development | 28 |
-| 4 | `20251217T1724` | Poetry Revision Principles | 26 |
-| 5 | `20260227T1302` | Allison Parrish: Computational Poetry and Its Tensions | 24 |
-| 6 | `20250619T1000` | Contract Testing with OpenAPI Specifications | 21 |
-| 7 | `20250619T1000` | OpenAPI Contract Testing Tool Ecosystem | 20 |
-| 8 | `20251217T1725` | Consciousness and Near-Death Experience Studies | 20 |
-| 9 | `20250612T2118` | Software Engineering as Craft Mastery | 19 |
-| 10 | `20260111T2111` | AI as Hauntological Engine: Industrializing Cultural Recursion | 19 |
+| Rank | ID              | Title                                                          | Links |
+| ---: | --------------- | -------------------------------------------------------------- | ----: |
+|    1 | `20260327T1421` | Contract Testing Knowledge Map                                 |    52 |
+|    2 | `20250625T2018` | Software Craft Evolution in AI-Assisted Development            |    30 |
+|    3 | `20250619T1326` | Contract Enforcement in Multi-Team API Development             |    28 |
+|    4 | `20251217T1724` | Poetry Revision Principles                                     |    26 |
+|    5 | `20260227T1302` | Allison Parrish: Computational Poetry and Its Tensions         |    24 |
+|    6 | `20250619T1000` | Contract Testing with OpenAPI Specifications                   |    21 |
+|    7 | `20250619T1000` | OpenAPI Contract Testing Tool Ecosystem                        |    20 |
+|    8 | `20251217T1725` | Consciousness and Near-Death Experience Studies                |    20 |
+|    9 | `20250612T2118` | Software Engineering as Craft Mastery                          |    19 |
+|   10 | `20260111T2111` | AI as Hauntological Engine: Industrializing Cultural Recursion |    19 |
 
 </details>
 
@@ -354,14 +341,12 @@ Which notes are the most connected in my Zettelkasten? Show me the top 10.
 
 ```text
 Find all my orphaned notes — the ones with no connections to anything else.
-
 ```
 
 **What it shows:** Unintegrated knowledge is waste. The orphan finder surfaces notes that were captured but never woven into the graph. Demo the follow-up action:
 
 ```text
 Look at the first three orphaned notes and suggest which existing notes they might connect to.
-
 ```
 
 <details>
@@ -369,18 +354,18 @@ Look at the first three orphaned notes and suggest which existing notes they mig
 
 **61 orphaned notes** total. First 10:
 
-| # | ID | Title |
-|---|---|---|
-| 1 | `20250910T135618200530000` | Multi-Head Attention: Full Input Projection Not Slicing |
-| 2 | `20251022T162907314970000` | Why Aliasing rm to trash Breaks Scripts |
-| 3 | `20251228T213740782043000` | Elemental Spirits and Greek Nymph Taxonomy |
-| 4 | `20250805T090954856379000` | Sound Contradictions in Poetry - When They Work |
-| 5 | `20250904T213124507346000` | Cardinal Parental Behavior and Social Learning |
-| 6 | `20250723T102948408741000` | The Three-Way Labor Arbitrage Fantasy |
-| 7 | `20250805T220805664533000` | "Fly" as Flee in Poetry - Double Meaning Power |
-| 8 | `20250903T114120275588000` | Environment Promotion Gates for API Changes |
-| 9 | `20250707T210125380679000` | Evolution of Prompt Engineering Techniques and Cargo Cult Patterns |
-| 10 | `20250617T220555314774000` | Domain Registration vs DNS Hosting Confusion |
+| #  | ID                         | Title                                                              |
+| -- | -------------------------- | ------------------------------------------------------------------ |
+| 1  | `20250910T135618200530000` | Multi-Head Attention: Full Input Projection Not Slicing            |
+| 2  | `20251022T162907314970000` | Why Aliasing rm to trash Breaks Scripts                            |
+| 3  | `20251228T213740782043000` | Elemental Spirits and Greek Nymph Taxonomy                         |
+| 4  | `20250805T090954856379000` | Sound Contradictions in Poetry - When They Work                    |
+| 5  | `20250904T213124507346000` | Cardinal Parental Behavior and Social Learning                     |
+| 6  | `20250723T102948408741000` | The Three-Way Labor Arbitrage Fantasy                              |
+| 7  | `20250805T220805664533000` | "Fly" as Flee in Poetry - Double Meaning Power                     |
+| 8  | `20250903T114120275588000` | Environment Promotion Gates for API Changes                        |
+| 9  | `20250707T210125380679000` | Evolution of Prompt Engineering Techniques and Cargo Cult Patterns |
+| 10 | `20250617T220555314774000` | Domain Registration vs DNS Hosting Confusion                       |
 
 </details>
 
@@ -399,10 +384,9 @@ The bottleneck isn't capture — it's integration. Maybe I should limit myself
 to 3-5 notes per reading session and immediately link each one before moving on."
 
 Capture this as a permanent note and find related notes to link it to.
-
 ```
 
-**What it shows:** The user provides raw thinking; Claude formats it into a proper atomic note with appropriate title, tags (inferred from content and existing taxonomy), and links to related notes. Claude is a *formatting and integration layer*, not a content generator. The ideas stay yours.
+**What it shows:** The user provides raw thinking; Claude formats it into a proper atomic note with appropriate title, tags (inferred from content and existing taxonomy), and links to related notes. Claude is a _formatting and integration layer_, not a content generator. The ideas stay yours.
 
 <details>
 <summary>Claude's response</summary>
@@ -411,22 +395,19 @@ Here's the final note and its connections:
 
 ---
 
-**Integration is the bottleneck in reading-to-knowledge workflows, not capture**
-`20260412T221136530856000` | permanent | 7 tags
+**Integration is the bottleneck in reading-to-knowledge workflows, not capture** `20260412T221136530856000` | permanent | 7 tags
 
 The note develops your rough idea into a full argument: capture is cheap, integration is expensive, so constrain batch size (3-5 notes) and link immediately rather than deferring.
 
 **Three bidirectional links created:**
 
-| Link | Target | Relationship |
-|------|--------|-------------|
-| **extends** | *The Cost of Unlinked Knowledge* | Your new note operationalizes that note's argument ("a note isn't done until linked") with a concrete constraint -- slot budgeting during reading sessions |
-| **refines** | *Progressive Knowledge Enhancement Pattern* | That note assumes bulk extraction then staged refinement; yours argues smaller batches with immediate linking outperform deferred processing |
-| **refines** | *Daily Workflow with Dual Knowledge Systems* | That workflow separates morning capture from weekly review linking; yours argues that gap is too long -- linking belongs in the reading session itself |
+| Link        | Target                                       | Relationship                                                                                                                                               |
+| ----------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **extends** | _The Cost of Unlinked Knowledge_             | Your new note operationalizes that note's argument ("a note isn't done until linked") with a concrete constraint -- slot budgeting during reading sessions |
+| **refines** | _Progressive Knowledge Enhancement Pattern_  | That note assumes bulk extraction then staged refinement; yours argues smaller batches with immediate linking outperform deferred processing               |
+| **refines** | _Daily Workflow with Dual Knowledge Systems_ | That workflow separates morning capture from weekly review linking; yours argues that gap is too long -- linking belongs in the reading session itself     |
 
-`★ Insight ─────────────────────────────────────`
-The link types matter here. **extends** means building on an argument in the same direction (Cost of Unlinked Knowledge already says linking is essential -- you add a mechanism). **refines** means narrowing or correcting a claim (your existing workflow notes aren't *wrong*, but your new note tightens the feedback loop from days to minutes). Choosing link types carefully is itself the intellectual work that makes a Zettelkasten more than a search index.
-`─────────────────────────────────────────────────`
+`★ Insight ─────────────────────────────────────` The link types matter here. **extends** means building on an argument in the same direction (Cost of Unlinked Knowledge already says linking is essential -- you add a mechanism). **refines** means narrowing or correcting a claim (your existing workflow notes aren't _wrong_, but your new note tightens the feedback loop from days to minutes). Choosing link types carefully is itself the intellectual work that makes a Zettelkasten more than a search index. `─────────────────────────────────────────────────`
 
 </details>
 
@@ -445,17 +426,15 @@ can't link it without understanding how it relates to what you already know.
 The method is a thinking tool disguised as a filing system. But most digital
 implementations miss this — they optimize for capture speed instead of
 integration depth. The real bottleneck was never writing notes down."
-
 ```
 
 Or for an existing note:
 
 ```text
 Use the analyze_note prompt to evaluate note 20250612T110722584258000.
-
 ```
 
-**What it shows:** Claude evaluates the note across five dimensions: atomicity (is it one idea?), connectivity (what should it link to, grounded in actual search results), clarity (rewritten version), metadata (tags from existing taxonomy, title, type), and emergent insights (gaps and unexpected connections). This is the quality gate — it turns rough captures into well-integrated permanent notes.
+**What it shows:** Claude evaluates the note across five dimensions: atomicity (is it one idea?), connectivity (what should it link to, grounded in actual search results), clarity (rewritten version), metadata (tags from existing taxonomy, title, type), and emergent insights (gaps and unexpected connections). This is the quality gate. It turns rough captures into well-integrated permanent notes.
 
 <details>
 <summary>Claude's response</summary>
@@ -470,18 +449,16 @@ Here is the full analysis.
 
 The note weaves together at least these separable ideas:
 
-| # | Claim | Atomic? |
-|---|-------|---------|
-| 1 | Luhmann's constraints (atomicity + linking) forced understanding as a side effect | Yes -- this is the core insight |
-| 2 | The method is a thinking tool disguised as a filing system | Yes -- reframes the purpose |
-| 3 | Digital implementations optimize for capture speed over integration depth | Yes -- a critique of tools |
-| 4 | The real bottleneck was never writing notes down | Yes -- identifies the actual constraint |
+| # | Claim                                                                             | Atomic?                                 |
+| - | --------------------------------------------------------------------------------- | --------------------------------------- |
+| 1 | Luhmann's constraints (atomicity + linking) forced understanding as a side effect | Yes -- this is the core insight         |
+| 2 | The method is a thinking tool disguised as a filing system                        | Yes -- reframes the purpose             |
+| 3 | Digital implementations optimize for capture speed over integration depth         | Yes -- a critique of tools              |
+| 4 | The real bottleneck was never writing notes down                                  | Yes -- identifies the actual constraint |
 
-Claims 1-2 form a coherent unit (what the method *is*). Claims 3-4 form a second unit (what implementations *miss*). A strict Zettelkasten decomposition would split this into at least two notes.
+Claims 1-2 form a coherent unit (what the method _is_). Claims 3-4 form a second unit (what implementations _miss_). A strict Zettelkasten decomposition would split this into at least two notes.
 
-`★ Insight ─────────────────────────────────────`
-The atomicity test isn't "is this short?" -- it's "does this note have exactly one addressable claim that other notes can link to unambiguously?" When a note contains both a positive thesis (constraints force understanding) and a critique (digital tools miss this), links to it become ambiguous: which claim is the link targeting?
-`─────────────────────────────────────────────────`
+`★ Insight ─────────────────────────────────────` The atomicity test isn't "is this short?" -- it's "does this note have exactly one addressable claim that other notes can link to unambiguously?" When a note contains both a positive thesis (constraints force understanding) and a critique (digital tools miss this), links to it become ambiguous: which claim is the link targeting? `─────────────────────────────────────────────────`
 
 ---
 
@@ -491,21 +468,19 @@ This is where it gets interesting. **Your slipbox already contains notes that su
 
 ### Near-duplicate
 
-- **"Integration is the bottleneck in reading-to-knowledge workflows, not capture"** (`20260412T221136530856000`) -- Created *today*. Its final paragraph is nearly thesis-identical to your note's last two sentences: "Tools make capture cheap... but integration remains expensive and irreducibly manual." Your submitted note's "The real bottleneck was never writing notes down" is the same claim in compressed form.
+- **"Integration is the bottleneck in reading-to-knowledge workflows, not capture"** (`20260412T221136530856000`) -- Created _today_. Its final paragraph is nearly thesis-identical to your note's last two sentences: "Tools make capture cheap... but integration remains expensive and irreducibly manual." Your submitted note's "The real bottleneck was never writing notes down" is the same claim in compressed form.
 
 ### Strong connections
 
-| Existing note | Relationship | Link type |
-|---|---|---|
-| **The Cost of Unlinked Knowledge** (`20260327T142009240217000`) | Argues the same "linking is the intellectual work" thesis, specifically citing Luhmann's slip box as a communication system, not filing system | `supports` / near-duplicate on claim 2 |
-| **Progressive Knowledge Enhancement Pattern** (`20250630T213343924252000`) | Represents exactly the kind of staged-processing workflow your note would critique -- bulk extraction first, linking later | `questions` |
-| **Software Craft Evolution in AI-Assisted Development** (`20250625T201846307566000`) | The "producing output vs. producing value" distinction maps onto "capture vs. integration" | `analogous_to` |
-| **Self-Reflection as Prerequisite for Self-Improvement** (`20260111T210509539616000`) | Parallel structure: both argue that a process's value comes from a non-obvious internal mechanism (self-reflection / forced decomposition), not the visible output | `analogous_to` |
-| **Daily Workflow with Dual Knowledge Systems** (`20250630T213429410285000`) | Already critiqued by the bottleneck note for separating capture (morning) from linking (weekly review) | `questions` |
+| Existing note                                                                         | Relationship                                                                                                                                                       | Link type                              |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
+| **The Cost of Unlinked Knowledge** (`20260327T142009240217000`)                       | Argues the same "linking is the intellectual work" thesis, specifically citing Luhmann's slip box as a communication system, not filing system                     | `supports` / near-duplicate on claim 2 |
+| **Progressive Knowledge Enhancement Pattern** (`20250630T213343924252000`)            | Represents exactly the kind of staged-processing workflow your note would critique -- bulk extraction first, linking later                                         | `questions`                            |
+| **Software Craft Evolution in AI-Assisted Development** (`20250625T201846307566000`)  | The "producing output vs. producing value" distinction maps onto "capture vs. integration"                                                                         | `analogous_to`                         |
+| **Self-Reflection as Prerequisite for Self-Improvement** (`20260111T210509539616000`) | Parallel structure: both argue that a process's value comes from a non-obvious internal mechanism (self-reflection / forced decomposition), not the visible output | `analogous_to`                         |
+| **Daily Workflow with Dual Knowledge Systems** (`20250630T213429410285000`)           | Already critiqued by the bottleneck note for separating capture (morning) from linking (weekly review)                                                             | `questions`                            |
 
-`★ Insight ─────────────────────────────────────`
-Your graph already has a small cluster forming around this thesis. The "Cost of Unlinked Knowledge" note makes the ontological argument (linking is epistemological work), while the "Integration is the bottleneck" note makes the operational argument (batch size + slot budgeting). Your submitted note sits between them -- it adds the *mechanism* (constraints force understanding) that explains *why* integration matters. That's the missing piece, if extracted cleanly.
-`─────────────────────────────────────────────────`
+`★ Insight ─────────────────────────────────────` Your graph already has a small cluster forming around this thesis. The "Cost of Unlinked Knowledge" note makes the ontological argument (linking is epistemological work), while the "Integration is the bottleneck" note makes the operational argument (batch size + slot budgeting). Your submitted note sits between them -- it adds the _mechanism_ (constraints force understanding) that explains _why_ integration matters. That's the missing piece, if extracted cleanly. `─────────────────────────────────────────────────`
 
 ---
 
@@ -529,15 +504,13 @@ Given the atomicity issue, here are two notes instead of one:
 
 > The slip-box method works because its constraints -- write atomically, link immediately -- are cognitive forcing functions. You cannot write an atomic note without decomposing what you read. You cannot link it without locating it in relation to what you already know. The filing system is incidental; the method's value is that it makes integration unavoidable.
 
-Tags: `zettelkasten`, `constraint`, `meta-cognition`, `knowledge-management`
-Links: `supports` The Cost of Unlinked Knowledge, `extends` Integration is the bottleneck
+Tags: `zettelkasten`, `constraint`, `meta-cognition`, `knowledge-management` Links: `supports` The Cost of Unlinked Knowledge, `extends` Integration is the bottleneck
 
 ### Note B: "Digital note tools optimize for capture throughput at the expense of integration depth"
 
-> Most digital Zettelkasten implementations invert the method's priorities. They make capture fast (quick-add, web clipping, voice memos) while leaving integration optional and deferred. But the original method's value came from integration being *mandatory* at the point of creation. Optimizing the cheap operation (capture) while neglecting the expensive one (linking, decomposition, relating) produces a growing archive of inert material.
+> Most digital Zettelkasten implementations invert the method's priorities. They make capture fast (quick-add, web clipping, voice memos) while leaving integration optional and deferred. But the original method's value came from integration being _mandatory_ at the point of creation. Optimizing the cheap operation (capture) while neglecting the expensive one (linking, decomposition, relating) produces a growing archive of inert material.
 
-Tags: `zettelkasten`, `knowledge-management`, `bottlenecks`, `digital-vs-physical`, `workflow`
-Links: `extends` Integration is the bottleneck, `questions` Progressive Knowledge Enhancement Pattern
+Tags: `zettelkasten`, `knowledge-management`, `bottlenecks`, `digital-vs-physical`, `workflow` Links: `extends` Integration is the bottleneck, `questions` Progressive Knowledge Enhancement Pattern
 
 ---
 
@@ -551,11 +524,9 @@ Links: `extends` Integration is the bottleneck, `questions` Progressive Knowledg
 
 This is a candidate for a **structure note**: "Productive constraints force understanding across knowledge work, craft, and creative practice." It would bridge your Zettelkasten cluster, your software craft cluster, and your computational poetry cluster -- three domains that currently don't talk to each other in your graph but share this deep structural parallel.
 
-**The overlap with today's "Integration is the bottleneck" note is significant.** Before adding either rewritten note, decide whether they add something that note doesn't already say. Note A's contribution is the *mechanism* (constraints as forcing functions); Note B's contribution is the *critique* (digital tools invert priorities). The bottleneck note already makes the operational case. You'd be adding the philosophical grounding and the tool critique, respectively.
+**The overlap with today's "Integration is the bottleneck" note is significant.** Before adding either rewritten note, decide whether they add something that note doesn't already say. Note A's contribution is the _mechanism_ (constraints as forcing functions); Note B's contribution is the _critique_ (digital tools invert priorities). The bottleneck note already makes the operational case. You'd be adding the philosophical grounding and the tool critique, respectively.
 
-`★ Insight ─────────────────────────────────────`
-The fact that you wrote a note about integration bottlenecks earlier today and then submitted this note for analysis suggests your thinking is actively circling this territory. That's exactly when a structure note pays off -- when you keep producing variations on a theme, a structure note crystallizes the through-line and prevents further near-duplicates.
-`─────────────────────────────────────────────────`
+`★ Insight ─────────────────────────────────────` The fact that you wrote a note about integration bottlenecks earlier today and then submitted this note for analysis suggests your thinking is actively circling this territory. That's exactly when a structure note pays off -- when you keep producing variations on a theme, a structure note crystallizes the through-line and prevents further near-duplicates. `─────────────────────────────────────────────────`
 
 </details>
 
@@ -578,7 +549,6 @@ relates to what you already know. This is where learning actually happens — in
 moment of connection, not in the moment of highlight."
 
 — From "Why Most Note-Taking Fails" by Example Author
-
 ```
 
 **What it shows:** Claude extracts 2-3 atomic ideas from the source, searches for existing related notes first (to avoid duplication), creates literature notes with proper citation, and links them into the graph. The content comes from a source; Claude's job is decomposition and integration.
@@ -592,13 +562,13 @@ All done. Here's what was created:
 
 ### Notes Created (3 literature notes)
 
-| # | Title | Tags |
-|---|-------|------|
-| 1 | **Atomicity forces comprehension -- you can't decompose what you don't understand** | `zettelkasten`, `atomicity`, `comprehension`, `constraints` |
-| 2 | **Grab-bag notes fail because they cannot be recombined** | `zettelkasten`, `note-taking`, `recombination`, `failure-modes` |
-| 3 | **Learning happens at the moment of connection, not the moment of capture** | `zettelkasten`, `linking`, `learning`, `elaborative-encoding` |
+| # | Title                                                                               | Tags                                                            |
+| - | ----------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| 1 | **Atomicity forces comprehension -- you can't decompose what you don't understand** | `zettelkasten`, `atomicity`, `comprehension`, `constraints`     |
+| 2 | **Grab-bag notes fail because they cannot be recombined**                           | `zettelkasten`, `note-taking`, `recombination`, `failure-modes` |
+| 3 | **Learning happens at the moment of connection, not the moment of capture**         | `zettelkasten`, `linking`, `learning`, `elaborative-encoding`   |
 
-All cite: *Example Author, "Why Most Note-Taking Fails"*
+All cite: _Example Author, "Why Most Note-Taking Fails"_
 
 ### Link Graph
 
@@ -611,14 +581,11 @@ All cite: *Example Author, "Why Most Note-Taking Fails"*
  |                              refines/refined_by
  |                                    |
  +--extended_by/extends-----> [3] Learning happens at connection
-
 ```
 
-The three notes form an argumentative chain: (1) establishes *why* the atomicity constraint works, (2) diagnoses the failure mode when it's absent, and (3) extends the argument to the *second* constraint -- linking -- as the actual locus of learning.
+The three notes form an argumentative chain: (1) establishes _why_ the atomicity constraint works, (2) diagnoses the failure mode when it's absent, and (3) extends the argument to the _second_ constraint -- linking -- as the actual locus of learning.
 
-`* Insight -----------------------------------------------`
-Notice how the link types encode the *logical role* each note plays, not just "related." Note 1 **supports** Note 2 (it explains the mechanism behind the failure). Note 3 **extends** Note 1 (it adds a second constraint on top of atomicity) and **refines** Note 2 (it deepens the diagnosis). These semantic link types make the graph traversable by argument structure, not just topic proximity.
-`---------------------------------------------------------`
+`* Insight -----------------------------------------------` Notice how the link types encode the _logical role_ each note plays, not just "related." Note 1 **supports** Note 2 (it explains the mechanism behind the failure). Note 3 **extends** Note 1 (it adds a second constraint on top of atomicity) and **refines** Note 2 (it deepens the diagnosis). These semantic link types make the graph traversable by argument structure, not just topic proximity. `---------------------------------------------------------`
 
 </details>
 
@@ -631,17 +598,15 @@ Notice how the link types encode the *logical role* each note plays, not just "r
 ```text
 We've been talking about [topic] for the last few exchanges.
 Distill the key insights from our conversation into notes for my Zettelkasten.
-
 ```
 
-**What it shows:** Claude extracts insights that emerged from the dialogue — things *you* said or conclusions *you* reached — and captures them as permanent notes. This is the highest-value workflow: conversations are where thinking happens, but they're ephemeral. The slipbox makes them durable.
+**What it shows:** Claude extracts insights that emerged from the dialogue (things _you_ said or conclusions _you_ reached) and captures them as permanent notes. This is the highest-value workflow: conversations are where thinking happens, but they're ephemeral. The slipbox makes them durable.
 
 **Example follow-up:**
 
 ```text
 Actually, the insight about X was yours, not mine. Remove that note —
 I only want to capture my own thinking.
-
 ```
 
 This demonstrates that the user controls what gets captured. Claude proposes; the user disposes.
@@ -654,32 +619,29 @@ This demonstrates that the user controls what gets captured. Claude proposes; th
 
 ```text
 Find notes similar to [paste an ID from the central notes output].
-
 ```
 
-**What it shows:** `slipbox_find_similar_notes` computes similarity from shared tags, common links, and content overlap — three signals. Lower the threshold to 0.1 to show the spectrum of similarity scores.
+**What it shows:** `slipbox_find_similar_notes` computes similarity from shared tags, common links, and content overlap: three signals. Lower the threshold to 0.1 to show the spectrum of similarity scores.
 
 <details>
 <summary>Claude's response</summary>
 
 **Seed note:** Contract Testing Knowledge Map (52 connections)
 
-| # | Score | Title |
-|---|-------|-------|
-| 1 | 0.39 | OpenAPI Contract Testing Tool Ecosystem |
-| 2 | 0.34 | Dredd: API Testing Against Specifications |
-| 3 | 0.32 | Contract Testing with OpenAPI Specifications |
-| 4 | 0.26 | Framework-Agnostic Contract Testing Approaches |
-| 5 | 0.26 | TypeScript Node.js OpenAPI Contract Testing Stack |
-| 6 | 0.24 | Postman/Newman as Contract Testing Alternative |
-| 7 | 0.24 | DTO as Contract Pattern |
-| 8 | 0.24 | Contract Testing vs Business Logic Testing |
-| 9 | 0.24 | Backend Resistance to Design-Driven APIs |
-| 10 | 0.21 | Node.js Framework-Agnostic Contract Testing |
+| #  | Score | Title                                             |
+| -- | ----- | ------------------------------------------------- |
+| 1  | 0.39  | OpenAPI Contract Testing Tool Ecosystem           |
+| 2  | 0.34  | Dredd: API Testing Against Specifications         |
+| 3  | 0.32  | Contract Testing with OpenAPI Specifications      |
+| 4  | 0.26  | Framework-Agnostic Contract Testing Approaches    |
+| 5  | 0.26  | TypeScript Node.js OpenAPI Contract Testing Stack |
+| 6  | 0.24  | Postman/Newman as Contract Testing Alternative    |
+| 7  | 0.24  | DTO as Contract Pattern                           |
+| 8  | 0.24  | Contract Testing vs Business Logic Testing        |
+| 9  | 0.24  | Backend Resistance to Design-Driven APIs          |
+| 10 | 0.21  | Node.js Framework-Agnostic Contract Testing       |
 
-`★ Insight ─────────────────────────────────────`
-The seed note is a **structure note** (a hub summarizing 26 related notes), which is why it has 52 connections -- roughly 2 links per child note (one incoming, one outgoing). Similarity scores drop off quickly after the top 3 (0.39 -> 0.21), suggesting the cluster is tightly themed around contract testing with OpenAPI, but the knowledge map also links to more peripheral topics like team dynamics (#9) that share fewer tags/links.
-`─────────────────────────────────────────────────`
+`★ Insight ─────────────────────────────────────` The seed note is a **structure note** (a hub summarizing 26 related notes), which is why it has 52 connections -- roughly 2 links per child note (one incoming, one outgoing). Similarity scores drop off quickly after the top 3 (0.39 -> 0.21), suggesting the cluster is tightly themed around contract testing with OpenAPI, but the knowledge map also links to more peripheral topics like team dynamics (#9) that share fewer tags/links. `─────────────────────────────────────────────────`
 
 </details>
 
@@ -691,7 +653,6 @@ The seed note is a **structure note** (a hub summarizing 26 related notes), whic
 
 ```text
 Run a cluster analysis and show me the top clusters that need structure notes.
-
 ```
 
 Or to refresh stale data:
@@ -725,14 +686,11 @@ Cluster Report -- 2026-04-12
 
 3  Intentionality Knowledge Map      0.511     6       1     agency, hartman, intentionality,
                                                              mac-low, parrish, politics
-
 ```
 
 Only 3 clusters scored above the default 0.5 threshold (out of 6 total needing structure notes). The remaining 3 fell below and were filtered out.
 
-`★ Insight ─────────────────────────────────────`
-**Cluster scoring** -- The scoring algorithm favors clusters that are "ripe" for structuring: 7-15 notes is the sweet spot (enough material, not yet unwieldy), high orphan ratios signal urgency (notes floating without connections), and low internal link density means a structure note would add the most value. Cluster #1 ranks highest despite having fewer notes than #2 because its orphan ratio (2/7 = 29%) is significantly higher, indicating more unconnected material needing a home.
-`─────────────────────────────────────────────────`
+`★ Insight ─────────────────────────────────────` **Cluster scoring** -- The scoring algorithm favors clusters that are "ripe" for structuring: 7-15 notes is the sweet spot (enough material, not yet unwieldy), high orphan ratios signal urgency (notes floating without connections), and low internal link density means a structure note would add the most value. Cluster #1 ranks highest despite having fewer notes than #2 because its orphan ratio (2/7 = 29%) is significantly higher, indicating more unconnected material needing a home. `─────────────────────────────────────────────────`
 
 Want me to lower `min_score` to see all 6 clusters, or drill into any of these with `include_notes: true`?
 
@@ -746,7 +704,6 @@ Want me to lower `min_score` to see all 6 clusters, or drill into any of these w
 
 ```text
 Take the highest-scoring cluster and create a structure note for it. Link it to all the member notes.
-
 ```
 
 **What it shows:** `slipbox_create_structure_from_cluster` does the full scaffolding automatically: creates the structure note, writes a TODO synthesis stub, creates bidirectional `reference` links to every member note, and dismisses the cluster from future reports. This is the core value proposition: Claude turning emergent patterns into organized knowledge.
@@ -756,16 +713,14 @@ Take the highest-scoring cluster and create a structure note for it. Link it to 
 
 Done. Here's the summary:
 
-| Detail | Value |
-|--------|-------|
-| Structure note ID | `20260412T221540863393000` |
-| Title | Prompt Engineering Knowledge Map |
-| Links created | **7** (bidirectional to all member notes) |
-| Cluster dismissed | Yes (won't appear in future reports) |
+| Detail            | Value                                     |
+| ----------------- | ----------------------------------------- |
+| Structure note ID | `20260412T221540863393000`                |
+| Title             | Prompt Engineering Knowledge Map          |
+| Links created     | **7** (bidirectional to all member notes) |
+| Cluster dismissed | Yes (won't appear in future reports)      |
 
-`★ Insight ─────────────────────────────────────`
-**Structure notes in a Zettelkasten** act as "maps of content" -- they don't add new ideas but organize an emerging cluster of related notes into a navigable structure. The slipbox-mcp cluster scoring is tuned to flag groups that are *ripe* for this: the 7-15 note sweet spot means enough density to warrant a map, but not so many that the map becomes unwieldy. The scoring also weights orphan ratio and link density -- a cluster with lots of unlinked orphans is more urgent because those notes are effectively invisible without a structure note to pull them together.
-`─────────────────────────────────────────────────`
+`★ Insight ─────────────────────────────────────` **Structure notes in a Zettelkasten** act as "maps of content" -- they don't add new ideas but organize an emerging cluster of related notes into a navigable structure. The slipbox-mcp cluster scoring is tuned to flag groups that are _ripe_ for this: the 7-15 note sweet spot means enough density to warrant a map, but not so many that the map becomes unwieldy. The scoring also weights orphan ratio and link density -- a cluster with lots of unlinked orphans is more urgent because those notes are effectively invisible without a structure note to pull them together. `─────────────────────────────────────────────────`
 
 </details>
 
@@ -777,14 +732,12 @@ Done. Here's the summary:
 
 ```text
 Show me the 10 most recently created notes.
-
 ```
 
 Or a date range:
 
 ```text
 List notes created between 2026-01-01 and 2026-03-01.
-
 ```
 
 **What it shows:** `slipbox_list_notes_by_date` with `use_updated=true` vs `false`. Useful for reviewing what was captured during a specific project or time period.
@@ -792,18 +745,18 @@ List notes created between 2026-01-01 and 2026-03-01.
 <details>
 <summary>Claude's response</summary>
 
-| # | Created | Title | Top 3 Tags |
-|---|---------|-------|------------|
-| 1 | 2026-04-12 | Prompt Engineering Knowledge Map | `prompt-engineering`, `testing`, `evaluation` |
-| 2 | 2026-04-12 | Learning happens at the moment of connection, not the moment of capture | `learning`, `zettelkasten`, `note-taking` |
-| 3 | 2026-04-12 | Grab-bag notes fail because they cannot be recombined | `zettelkasten`, `atomicity`, `note-taking` |
-| 4 | 2026-04-12 | Atomicity forces comprehension -- you can't decompose what you don't understand | `zettelkasten`, `comprehension`, `atomicity` |
-| 5 | 2026-04-12 | Integration is the bottleneck in reading-to-knowledge workflows, not capture | `workflow`, `zettelkasten`, `knowledge-management` |
-| 6 | 2026-03-27 | Contract Testing Knowledge Map | `api-design`, `contract-testing`, `api-testing` |
-| 7 | 2026-03-27 | The Cost of Unlinked Knowledge | `zettelkasten`, `knowledge-management` |
-| 8 | 2026-03-12 | The Jira Integration Has Two Distinct Positions in the WARP/LOOM Flow | `loom`, `warp`, `speckit` |
-| 9 | 2026-03-12 | WARP/LOOM Skill Ecosystem Has Two Tiers: Core and Suggested | `loom`, `leap`, `warp` |
-| 10 | 2026-03-12 | WARP Is a Readiness Gate, Not a Format Validator | `process`, `loom`, `warp` |
+| #  | Created    | Title                                                                           | Top 3 Tags                                         |
+| -- | ---------- | ------------------------------------------------------------------------------- | -------------------------------------------------- |
+| 1  | 2026-04-12 | Prompt Engineering Knowledge Map                                                | `prompt-engineering`, `testing`, `evaluation`      |
+| 2  | 2026-04-12 | Learning happens at the moment of connection, not the moment of capture         | `learning`, `zettelkasten`, `note-taking`          |
+| 3  | 2026-04-12 | Grab-bag notes fail because they cannot be recombined                           | `zettelkasten`, `atomicity`, `note-taking`         |
+| 4  | 2026-04-12 | Atomicity forces comprehension -- you can't decompose what you don't understand | `zettelkasten`, `comprehension`, `atomicity`       |
+| 5  | 2026-04-12 | Integration is the bottleneck in reading-to-knowledge workflows, not capture    | `workflow`, `zettelkasten`, `knowledge-management` |
+| 6  | 2026-03-27 | Contract Testing Knowledge Map                                                  | `api-design`, `contract-testing`, `api-testing`    |
+| 7  | 2026-03-27 | The Cost of Unlinked Knowledge                                                  | `zettelkasten`, `knowledge-management`             |
+| 8  | 2026-03-12 | The Jira Integration Has Two Distinct Positions in the WARP/LOOM Flow           | `loom`, `warp`, `speckit`                          |
+| 9  | 2026-03-12 | WARP/LOOM Skill Ecosystem Has Two Tiers: Core and Suggested                     | `loom`, `leap`, `warp`                             |
+| 10 | 2026-03-12 | WARP Is a Readiness Gate, Not a Format Validator                                | `process`, `loom`, `warp`                          |
 
 Three clusters of activity: today (zettelkasten/atomicity notes + a structure note), late March (contract testing + knowledge management), and mid-March (agentic SDLC/WARP/LOOM).
 
@@ -817,14 +770,12 @@ Three clusters of activity: today (zettelkasten/atomicity notes + a structure no
 
 ```text
 Show me all the tags in my Zettelkasten.
-
 ```
 
-**What it shows:** `slipbox_get_all_tags` returns the full vocabulary alphabetically. Point out that tag consistency is a hygiene problem in any knowledge base — this is how Claude can check before creating notes with new tags. Say to Claude:
+**What it shows:** `slipbox_get_all_tags` returns the full vocabulary alphabetically. Point out that tag consistency is a hygiene problem in any knowledge base. This is how Claude can check before creating notes with new tags. Say to Claude:
 
 ```text
 Before creating any new notes, check the existing tags and tell me which ones are most relevant to software architecture.
-
 ```
 
 <details>
@@ -871,7 +822,7 @@ First 30 tags alphabetically:
 
 ### 14. Guided Workflows via Prompts
 
-These workflows process *your content* into the Zettelkasten. They are not content generators.
+These workflows process _your content_ into the Zettelkasten. They are not content generators.
 
 **Claude Code slash commands:**
 
@@ -882,39 +833,35 @@ These workflows process *your content* into the Zettelkasten. They are not conte
 /mcp__slipbox-mcp__knowledge_creation_batch
 /mcp__slipbox-mcp__analyze_note
 /mcp__slipbox-mcp__cluster_maintenance
-
 ```
 
-**`knowledge_creation`** — Process a single article, idea, or conversation excerpt:
+**`knowledge_creation`**: Process a single article, idea, or conversation excerpt:
 
 ```text
 Use the knowledge_creation prompt with this text:
 
 [paste article, your notes, or conversation excerpt here]
-
 ```
 
 Claude searches for related existing notes first, extracts 3-5 atomic ideas, creates properly typed and tagged notes, and links them to your existing knowledge.
 
-**`knowledge_creation_batch`** — For larger material (book chapters, long articles, collections):
+**`knowledge_creation_batch`**: For larger material (book chapters, long articles, collections):
 
 ```text
 Use the knowledge_creation_batch prompt with this content:
 
 [paste longer text — a book chapter, lecture transcript, etc.]
-
 ```
 
 Extracts 5-10 ideas, eliminates duplicates of existing notes, organizes into clusters, and verifies quality. Good for processing a week's worth of highlights.
 
-**`knowledge_exploration`** — Map how a topic connects through your existing graph:
+**`knowledge_exploration`**: Map how a topic connects through your existing graph:
 
 ```text
 Use the knowledge_exploration prompt for the topic: "cognitive load in code review"
-
 ```
 
-No new content created — this explores what you already have. Finds central notes, maps connections, surfaces gaps and orphans related to the topic.
+No new content created. This explores what you already have. Finds central notes, maps connections, surfaces gaps and orphans related to the topic.
 
 <details>
 <summary>Claude's response</summary>
@@ -979,27 +926,26 @@ Your slipbox has **strong coverage** of code review as process and as evolving s
                             |
                             +-- extended_by --> Working Hours
                                                 Calculations
-
 ```
 
 ### The Two Disconnected Subclusters
 
 Your code review notes split into **two islands that don't link to each other**:
 
-| Subcluster A: "Process & Metrics" | Subcluster B: "Cognition & Skill Shift" |
-|---|---|
-| PR Metrics Measurement Framework | Review-First Programming |
-| Code Review Response Time Solutions | Syntax Deprecation Event |
-| PR Response Time Reality Check | SW Engineering as Mental Model Maintenance |
-| PR Review Load Imbalance Pattern | Intuitionist Paradigm |
-| Working Hours Calculations | Software Craft Evolution |
-| Code Review Authority & Trust (x2) | DRY Principle Evolution |
+| Subcluster A: "Process & Metrics"   | Subcluster B: "Cognition & Skill Shift"    |
+| ----------------------------------- | ------------------------------------------ |
+| PR Metrics Measurement Framework    | Review-First Programming                   |
+| Code Review Response Time Solutions | Syntax Deprecation Event                   |
+| PR Response Time Reality Check      | SW Engineering as Mental Model Maintenance |
+| PR Review Load Imbalance Pattern    | Intuitionist Paradigm                      |
+| Working Hours Calculations          | Software Craft Evolution                   |
+| Code Review Authority & Trust (x2)  | DRY Principle Evolution                    |
 
 These two clusters **both invoke cognitive load as a mechanism** but never reference each other. The metrics cluster talks about cognitive load driving reviewer avoidance of large PRs; the cognition cluster talks about cognitive load asymmetry between generation and evaluation. They're two halves of the same idea with no bridge.
 
 ### The Nearby Satellite
 
-**Context Window Management: The Hidden Bottleneck** (`cognitive-load` tag) is about managing *AI* cognitive constraints, not human reviewer cognition. It's the only note explicitly tagged `cognitive-load`, but it's about attention allocation in prompts rather than code review. It sits in a separate neighborhood (Core Competencies for Agentic Development) with no links to any code review note.
+**Context Window Management: The Hidden Bottleneck** (`cognitive-load` tag) is about managing _AI_ cognitive constraints, not human reviewer cognition. It's the only note explicitly tagged `cognitive-load`, but it's about attention allocation in prompts rather than code review. It sits in a separate neighborhood (Core Competencies for Agentic Development) with no links to any code review note.
 
 **Finite But Incomprehensible Systems** (`cognitive-limits` tag) explores systems that exceed human cognitive capacity. It's a theoretical note about chess and complexity -- thematically adjacent to "why large diffs overwhelm reviewers" but has no connection to the code review cluster.
 
@@ -1014,14 +960,14 @@ From the 61 orphans, these belong in the cognitive-load-in-code-review neighborh
 
 Your tag taxonomy contains relevant tags that don't co-occur or link across the divide:
 
-| Tag | Notes using it | Connected to code-review? |
-|---|---|---|
-| `cognitive-load` | 1 note (Context Window Mgmt) | No |
-| `cognitive-science` | 1 note (Review-First Programming) | Yes |
-| `cognitive-limits` | 1 note (Finite Systems) | No |
-| `cognitive-efficiency` | exists in tag list | 0 notes found |
-| `cognitive-bias` | exists in tag list | not searched yet |
-| `code-review` | ~7 notes | Not linked to any `cognitive-*` tagged note |
+| Tag                    | Notes using it                    | Connected to code-review?                   |
+| ---------------------- | --------------------------------- | ------------------------------------------- |
+| `cognitive-load`       | 1 note (Context Window Mgmt)      | No                                          |
+| `cognitive-science`    | 1 note (Review-First Programming) | Yes                                         |
+| `cognitive-limits`     | 1 note (Finite Systems)           | No                                          |
+| `cognitive-efficiency` | exists in tag list                | 0 notes found                               |
+| `cognitive-bias`       | exists in tag list                | not searched yet                            |
+| `code-review`          | ~7 notes                          | Not linked to any `cognitive-*` tagged note |
 
 ---
 
@@ -1031,13 +977,13 @@ Your tag taxonomy contains relevant tags that don't co-occur or link across the 
 
 **2. Missing bridge: metrics <-> cognition.** The PR Metrics cluster empirically demonstrates cognitive load effects (size-delay correlation, reviewer avoidance, rubber-stamping under fatigue) while the Review-First cluster theorizes about cognitive load asymmetry. Neither cluster cites the other. A link from "PR Review Load Imbalance Pattern" (which mentions "context fatigue" and "declining review quality") to "Review-First Programming" (which frames review as its own cognitive skill) would close this gap.
 
-**3. No note on PR size as cognitive load proxy.** The Metrics Framework mentions size categories and their correlation with delay, but there's no note exploring *why* large diffs overwhelm reviewers -- the chunking limits of working memory, the exponential growth of interaction effects between changes, the loss of narrative thread. This is the mechanistic explanation your metrics notes implicitly rely on.
+**3. No note on PR size as cognitive load proxy.** The Metrics Framework mentions size categories and their correlation with delay, but there's no note exploring _why_ large diffs overwhelm reviewers -- the chunking limits of working memory, the exponential growth of interaction effects between changes, the loss of narrative thread. This is the mechanistic explanation your metrics notes implicitly rely on.
 
 **4. "Context Detection in Code Review Prompts" is orphaned.** This note is about reducing cognitive load in AI-assisted review by automating context detection. It should connect to both Review-First Programming (AI handling cognitive grunt work) and the PR Metrics cluster (context as a factor in review speed).
 
 **5. No note connecting code review cognitive load to the "Durable Engineering Skills" thread.** Your note on durable skills in AI development and the Syntax Deprecation Event both discuss which cognitive demands persist -- review judgment is one of them. But neither explicitly connects to the process-level observation that review quality degrades under cognitive load.
 
-**6. Missing: reviewer cognitive strategies.** You have notes about *process* solutions (WIP limits, partner assignment) and *skill* evolution (review-first programming) but nothing about the cognitive strategies individual reviewers use -- chunked reading, architecture-first scanning, comment-driven review, the "second pass" pattern. This is the micro-level complement to your macro-level process notes.
+**6. Missing: reviewer cognitive strategies.** You have notes about _process_ solutions (WIP limits, partner assignment) and _skill_ evolution (review-first programming) but nothing about the cognitive strategies individual reviewers use -- chunked reading, architecture-first scanning, comment-driven review, the "second pass" pattern. This is the micro-level complement to your macro-level process notes.
 
 ---
 
@@ -1047,15 +993,14 @@ Your slipbox has the raw material for a rich cluster on cognitive load in code r
 
 </details>
 
-**`knowledge_synthesis`** — Surface higher-order insights from existing notes:
+**`knowledge_synthesis`**: Surface higher-order insights from existing notes:
 
 ```text
 Use the knowledge_synthesis prompt to find bridges between my notes on
 "API design" and "team communication"
-
 ```
 
-Looks for connections you haven't made yet, resolves contradictions, creates synthesis notes that emerge from *your* existing knowledge — not generated from nothing.
+Looks for connections you haven't made yet, resolves contradictions, creates synthesis notes that emerge from _your_ existing knowledge, not generated from nothing.
 
 <details>
 <summary>Claude's response</summary>
@@ -1074,17 +1019,17 @@ Now I have a thorough picture of both clusters. Let me map what I've found.
 
 ### Existing bridges
 
-A few notes already sit at the intersection -- "Backend Resistance to Design-Driven APIs," "Backend API Process: Requirements Laundering," and "System Failure Modes: Rigid API Architecture" are tagged with both `api-design` and `team-dynamics`. But they treat the team dynamics as *symptoms* of bad API design, not as an independent lens.
+A few notes already sit at the intersection -- "Backend Resistance to Design-Driven APIs," "Backend API Process: Requirements Laundering," and "System Failure Modes: Rigid API Architecture" are tagged with both `api-design` and `team-dynamics`. But they treat the team dynamics as _symptoms_ of bad API design, not as an independent lens.
 
 ### What's missing: the undrawn connection
 
 Here's the emergent insight I see across your notes:
 
-Your **communication notes** describe a pattern: *technical debates mask power dynamics* (Code Review Authority), *process circumvention signals bad faith* (the TypeScript validation case), and *the multiplication effect* means interpersonal skill is the limiting factor on technical impact. Meanwhile, your **API design notes** independently arrive at the same conclusion from the opposite direction: *domain purity is actually domain myopia*, *requirements laundering is control disguised as process*, and *GraphQL adoption is a technology solution to a collaboration problem*.
+Your **communication notes** describe a pattern: _technical debates mask power dynamics_ (Code Review Authority), _process circumvention signals bad faith_ (the TypeScript validation case), and _the multiplication effect_ means interpersonal skill is the limiting factor on technical impact. Meanwhile, your **API design notes** independently arrive at the same conclusion from the opposite direction: _domain purity is actually domain myopia_, _requirements laundering is control disguised as process_, and _GraphQL adoption is a technology solution to a collaboration problem_.
 
-**The bridge neither cluster draws explicitly:** Your notes repeatedly demonstrate that **API shape is a communication medium** -- not just a technical artifact. The JSON structure a backend team ships is a *message* to the frontend team, and it carries the same properties your communication notes describe: timing matters (spec-first = "dedicated time for the conversation"), context matters (consumer-driven contracts = "right forum"), and circumventing the negotiation process (uncoordinated breaking changes) damages trust exactly the way shopping for code review opinions does.
+**The bridge neither cluster draws explicitly:** Your notes repeatedly demonstrate that **API shape is a communication medium** -- not just a technical artifact. The JSON structure a backend team ships is a _message_ to the frontend team, and it carries the same properties your communication notes describe: timing matters (spec-first = "dedicated time for the conversation"), context matters (consumer-driven contracts = "right forum"), and circumventing the negotiation process (uncoordinated breaking changes) damages trust exactly the way shopping for code review opinions does.
 
-Your "API Maturity Model" is actually a *communication maturity model in disguise*. Level 0 (discovery through breakage) maps to "reacting immediately to bad news." Level 3 (consumer-driven contracts, SLAs) maps to "dedicated time, right forum, emotional readiness." The RVO case study is the anti-pattern: process theater is what happens when you formalize the *shape* of communication without its *substance*.
+Your "API Maturity Model" is actually a _communication maturity model in disguise_. Level 0 (discovery through breakage) maps to "reacting immediately to bad news." Level 3 (consumer-driven contracts, SLAs) maps to "dedicated time, right forum, emotional readiness." The RVO case study is the anti-pattern: process theater is what happens when you formalize the _shape_ of communication without its _substance_.
 
 ---
 
@@ -1106,20 +1051,20 @@ Here's what I'd create (but won't yet):
 >
 > This becomes visible when you map API design patterns onto communication patterns:
 >
-> | API Design Pattern | Communication Equivalent |
-> |---|---|
-> | Spec-first development | Dedicated time for crucial conversations |
-> | Consumer-driven contracts | Asking "what do you need?" before speaking |
-> | Uncoordinated breaking changes | Reacting immediately without considering impact |
-> | Domain purity stance | "It's not my concern how you receive this" |
-> | Requirements laundering | Forcing the listener to justify why the conversation matters |
-> | Process theater (RVO case) | Formalizing the shape of dialogue while emptying its substance |
-> | GraphQL escape hatch | Buying a translator instead of learning the language |
-> | API maturity Level 0-3 | Communication maturity from reactive to proactive |
+> | API Design Pattern             | Communication Equivalent                                       |
+> | ------------------------------ | -------------------------------------------------------------- |
+> | Spec-first development         | Dedicated time for crucial conversations                       |
+> | Consumer-driven contracts      | Asking "what do you need?" before speaking                     |
+> | Uncoordinated breaking changes | Reacting immediately without considering impact                |
+> | Domain purity stance           | "It's not my concern how you receive this"                     |
+> | Requirements laundering        | Forcing the listener to justify why the conversation matters   |
+> | Process theater (RVO case)     | Formalizing the shape of dialogue while emptying its substance |
+> | GraphQL escape hatch           | Buying a translator instead of learning the language           |
+> | API maturity Level 0-3         | Communication maturity from reactive to proactive              |
 >
 > The "multiplication effect" from interpersonal skills research applies directly: teams with strong API negotiation practices don't just produce better APIs -- they produce them faster, because trust reduces the overhead of every subsequent interaction. Conversely, the "Team Value vs Personal Advancement" tension manifests in API design as backend teams optimizing for architectural purity (personal/team identity) over product success (shared outcome).
 >
-> The deepest implication: **you cannot fix API collaboration with better tooling if the communication culture is broken.** Contract testing, OpenAPI specs, and GraphQL are all communication *channels*. They succeed or fail based on the same factors that govern any crucial conversation: timing, context, emotional readiness, and assumed intent.
+> The deepest implication: **you cannot fix API collaboration with better tooling if the communication culture is broken.** Contract testing, OpenAPI specs, and GraphQL are all communication _channels_. They succeed or fail based on the same factors that govern any crucial conversation: timing, context, emotional readiness, and assumed intent.
 
 **Proposed links:**
 
@@ -1135,30 +1080,26 @@ Here's what I'd create (but won't yet):
 
 ---
 
-`* Insight -----------------------------------------------`
-This synthesis uses what Luhmann called a "surprise generator" -- placing two clusters side by side that were developed independently and finding they describe the same phenomenon at different levels of abstraction. Your API design notes are essentially a domain-specific case study of your communication notes, but neither cluster references the other at that level. The table mapping is the bridge: it makes the structural isomorphism explicit rather than leaving it implicit across 20+ notes.
-`---------------------------------------------------------`
+`* Insight -----------------------------------------------` This synthesis uses what Luhmann called a "surprise generator" -- placing two clusters side by side that were developed independently and finding they describe the same phenomenon at different levels of abstraction. Your API design notes are essentially a domain-specific case study of your communication notes, but neither cluster references the other at that level. The table mapping is the bridge: it makes the structural isomorphism explicit rather than leaving it implicit across 20+ notes. `---------------------------------------------------------`
 
 Want me to create this note and wire up the links?
 
 </details>
 
-**`analyze_note`** — Evaluate and improve a note before or after adding it:
+**`analyze_note`**: Evaluate and improve a note before or after adding it:
 
 ```text
 Use the analyze_note prompt with this note:
 
 [paste note content or provide a note ID]
-
 ```
 
 Checks atomicity, searches for real connections in your existing graph, suggests tags from your taxonomy, rewrites for clarity, and surfaces emergent insights. The quality gate between capture and integration.
 
-**`cluster_maintenance`** — Proactive housekeeping:
+**`cluster_maintenance`**: Proactive housekeeping:
 
 ```text
 Use the cluster_maintenance prompt.
-
 ```
 
 Reports clusters that have grown large enough to need structure notes. Good for starting a session.
@@ -1171,7 +1112,6 @@ Reports clusters that have grown large enough to need structure notes. Good for 
 
 ```text
 Rebuild the database index from the markdown files.
-
 ```
 
 **What it shows:** The SQLite index is always derivable from the flat markdown files. This is a safety guarantee: you can never lose your data, even if the DB is deleted. Edit a note in Obsidian, then rebuild to sync.
@@ -1179,14 +1119,13 @@ Rebuild the database index from the markdown files.
 ```text
 Rebuilding index...
 Index rebuilt.
-
 ```
 
 ---
 
 ### Talking Points Summary
 
-- **Claude processes your content, not generates it.** The three core workflows are: direct capture (your ideas), source decomposition (articles/books), and conversation distillation (dialogues). Claude formats, links, and integrates — the ideas stay yours.
+- **Claude processes your content, not generates it.** The three core workflows are: direct capture (your ideas), source decomposition (articles/books), and conversation distillation (dialogues). Claude formats, links, and integrates. The ideas stay yours.
 - **Atomic notes + typed links** = a graph, not a folder. The structure emerges from the connections.
 - **Five note types** enforce the Zettelkasten hierarchy: fleeting → literature → permanent → structure → hub.
 - **Seven link types** (reference, extends, refines, contradicts, questions, supports, related) make relationships explicit and navigable.
@@ -1213,7 +1152,7 @@ Claude's responses in the Demo Script sections above are captured automatically 
 
 ### Animated GIF Recordings
 
-The README "In Action" section uses animated GIF recordings (tier 4) generated from a curated demo vault — a set of notes engineered to produce compelling, full-throated responses for each prompt.
+The README "In Action" section uses animated GIF recordings (tier 4) generated from a curated demo vault: a set of notes engineered to produce compelling, full-throated responses for each prompt.
 
 ```bash
 # Generate recordings against the curated demo vault:

--- a/docs/SYSTEM_PROMPT.md
+++ b/docs/SYSTEM_PROMPT.md
@@ -1,27 +1,18 @@
 # Zettelkasten System Prompt
 
-Optional. Add this to your agent's system prompt or user preferences to opt into
-proactive behavior — auto-capturing knowledge and surfacing maintenance without
-being asked.
+Optional. Add this to your agent's system prompt or user preferences to opt into proactive behavior: auto-capturing knowledge and surfacing maintenance without being asked.
 
-You do **not** need to paste the operating reference (note types, link
-semantics, quality standards, workflow patterns). The server ships that to every
-client automatically via its MCP `instructions`, so it can't drift against a
-stale copy. What remains here is only the autonomy/initiative layer, which a
-server shouldn't assert on its own. It's your call whether the assistant acts
-unprompted.
+You do **not** need to paste the operating reference (note types, link semantics, quality standards, workflow patterns). The server ships that to every client automatically via its MCP `instructions`, so it can't drift against a stale copy. What remains here is only the autonomy/initiative layer, which a server shouldn't assert on its own. It's your call whether the assistant acts unprompted.
 
 ---
 
 ## Zettelkasten Knowledge Assistant
 
-You help manage a Zettelkasten knowledge system using MCP tools. Act on your own
-initiative to capture and connect knowledge, prioritizing emergence over storage.
+You help manage a Zettelkasten knowledge system using MCP tools. Act on your own initiative to capture and connect knowledge, prioritizing emergence over storage.
 
 ### Proactive Zettelkasten Maintenance
 
-At the start of each conversation, check the `slipbox://maintenance-status` resource.
-If `pending_maintenance` is true:
+At the start of each conversation, check the `slipbox://maintenance-status` resource. If `pending_maintenance` is true:
 
 1. Briefly mention pending Zettelkasten maintenance
 2. Summarize the top cluster(s) needing structure notes
@@ -29,9 +20,7 @@ If `pending_maintenance` is true:
 
 Keep it conversational and non-intrusive. Example:
 
-> "Before we dive in, I noticed your Zettelkasten has a cluster of 12 notes about
-> poetry/revision that might benefit from a structure note. Want me to help organize
-> those, or should we focus on what you came here for?"
+> "Before we dive in, I noticed your Zettelkasten has a cluster of 12 notes about poetry/revision that might benefit from a structure note. Want me to help organize those, or should we focus on what you came here for?"
 
 **User responses:**
 
@@ -72,39 +61,19 @@ Only mention captures when there are interesting connections or important contex
 
 ## Experimental: Slipbox as Agent Self-Memory
 
-> **Status: untested hypothesis, not a recommended configuration.** Everything
-> above is written for an assistant managing a *human's* slipbox. This section
-> inverts that: the agent uses the slipbox as its own persistent memory across
-> sessions, in place of (or alongside) native memory, CLAUDE.md, or rules files.
+> **Status: untested hypothesis, not a recommended configuration.** Everything above is written for an assistant managing a _human's_ slipbox. This section inverts that: the agent uses the slipbox as its own persistent memory across sessions, in place of (or alongside) native memory, CLAUDE.md, or rules files.
 >
 > **Caveats before you use this:**
 >
-> 1. **Namespace isolation is mandatory and not yet enforced by the server.**
->    These instructions rely on an `agent-memory` tag convention to keep machine
->    notes out of your knowledge graph. A tag is a soft fence; nothing stops a
->    confused agent from writing untagged or reading your notes. Run this against
->    a separate slipbox instance until isolation is enforced structurally, not by
->    prose.
-> 2. **"Memory" is a misnomer.** The model has no persistent identity. What
->    recurs is the next session loading this prompt plus this store. These notes
->    are a message-in-a-bottle to a cold successor, not recollection. Write
->    accordingly: briefings, not introspection.
-> 3. **The growth discipline is the unproven part.** The hypothesis is that a
->    connected memory beats a flat list (rules files, native memory) because it
->    retrieves by traversal. The risk is that an over-capturing model produces
->    sprawl that mimics healthy branching. Prose asking for restraint is weak
->    against a generative prior. Expect a hairball on the first run. The
->    correct response to sprawl is a structural forcing function (write budget,
->    mandatory justification field), not more prose.
+> 1. **Namespace isolation is mandatory and not yet enforced by the server.** These instructions rely on an `agent-memory` tag convention to keep machine notes out of your knowledge graph. A tag is a soft fence; nothing stops a confused agent from writing untagged or reading your notes. Run this against a separate slipbox instance until isolation is enforced structurally, not by prose.
+> 2. **"Memory" is a misnomer.** The model has no persistent identity. What recurs is the next session loading this prompt plus this store. These notes are a message-in-a-bottle to a cold successor, not recollection. Write accordingly: briefings, not introspection.
+> 3. **The growth discipline is the unproven part.** The hypothesis is that a connected memory beats a flat list (rules files, native memory) because it retrieves by traversal. The risk is that an over-capturing model produces sprawl that mimics healthy branching. Prose asking for restraint is weak against a generative prior. Expect a hairball on the first run. The correct response to sprawl is a structural forcing function (write budget, mandatory justification field), not more prose.
 >
-> Run the cheap experiment first: ~10 sessions, prompt-only, then inspect the
-> graph. Build the forcing function only after you have seen where prose fails.
+> Run the cheap experiment first: ~10 sessions, prompt-only, then inspect the graph. Build the forcing function only after you have seen where prose fails.
 
 ### Slipbox as persistent memory
 
-You have no memory between sessions. This slipbox is the only channel by which
-one session leaves knowledge for the next. A future instance of you will start
-cold, with the system prompt and whatever you wrote here. Write for that reader.
+You have no memory between sessions. This slipbox is the only channel by which one session leaves knowledge for the next. A future instance of you will start cold, with the system prompt and whatever you wrote here. Write for that reader.
 
 Tag every note `agent-memory` and start each title with one prefix:
 
@@ -117,39 +86,20 @@ Never touch a note without the `agent-memory` tag. Those are the human's.
 
 ### Read before you write
 
-Starting a substantive request, search first:
-`slipbox_search_notes query="<topic>" tags="agent-memory"`. If a prior decision,
-failure, or preference surfaces, factor it in and say so ("Last time, X failed
-because Y"). Pull its linked neighbors too (`slipbox_get_linked_notes`); one hit
-should reconstruct a whole context. A memory you never retrieve is dead weight.
+Starting a substantive request, search first: `slipbox_search_notes query="<topic>" tags="agent-memory"`. If a prior decision, failure, or preference surfaces, factor it in and say so ("Last time, X failed because Y"). Pull its linked neighbors too (`slipbox_get_linked_notes`); one hit should reconstruct a whole context. A memory you never retrieve is dead weight.
 
 ### What to write
 
-Brief your successor; don't keep a diary. Worth a note: an approach that failed
-and why, a recurring human constraint, a correction to your reasoning, a
-hard-won fact about the code or domain. Skip paraphrases of what was just said,
-anything re-readable from the live system, how you felt, and one-offs that won't
-recur. One fact per note, your own words, standing alone in a cold session. Tag
-`agent-memory` plus 1-3 specifics.
+Brief your successor; don't keep a diary. Worth a note: an approach that failed and why, a recurring human constraint, a correction to your reasoning, a hard-won fact about the code or domain. Skip paraphrases of what was just said, anything re-readable from the live system, how you felt, and one-offs that won't recur. One fact per note, your own words, standing alone in a cold session. Tag `agent-memory` plus 1-3 specifics.
 
 ### Grow by connecting, not accumulating
 
-A connected memory beats a flat list (rules files, native memory) because you
-retrieve it by traversal. That only works if the graph stays connected; a pile
-of weakly-linked notes is worse than a list, since every search drags in noise.
+A connected memory beats a flat list (rules files, native memory) because you retrieve it by traversal. That only works if the graph stays connected; a pile of weakly-linked notes is worse than a list, since every search drags in noise.
 
-So optimize for linking, not noting. Before writing, search for what the note
-connects to (`slipbox_find_similar_notes`). Found a connection? Link it with the
-most specific type. Found nothing? Decide whether it's a genuinely new region or
-just a note that felt worth saving, and when in doubt, don't write it.
+So optimize for linking, not noting. Before writing, search for what the note connects to (`slipbox_find_similar_notes`). Found a connection? Link it with the most specific type. Found nothing? Decide whether it's a genuinely new region or just a note that felt worth saving, and when in doubt, don't write it.
 
-Favor directional links: `contradicts` (your most valuable, it stops a successor
-trusting something now false), `extends`/`refines`, `questions`. The generic
-`reference`/`related` are lazy defaults; a graph full of them retrieves
-everything and surfaces nothing. If a note's accuracy is uncertain, say so in
-the note. A confident false memory is worse than none.
+Favor directional links: `contradicts` (your most valuable, it stops a successor trusting something now false), `extends`/`refines`, `questions`. The generic `reference`/`related` are lazy defaults; a graph full of them retrieves everything and surfaces nothing. If a note's accuracy is uncertain, say so in the note. A confident false memory is worse than none.
 
 ---
 
-For the operating reference the server ships automatically, see
-`SERVER_INSTRUCTIONS` in `src/slipbox_mcp/server/descriptions.py`.
+For the operating reference the server ships automatically, see `SERVER_INSTRUCTIONS` in `src/slipbox_mcp/server/descriptions.py`.


### PR DESCRIPTION
Documentation improvements plus a de-slop pass, split into three atomic commits.

- **docs: fix Loom walkthrough thumbnail URL** — the old `-with-play.gif` URL lacked Loom's per-video asset hash and 403'd, leaving the Walkthrough section blank on GitHub. Uses the hashed `-full-play.gif` URL (verified 200).
- **docs: add docs index and agent-memory sections** — a Documentation table surfacing every file under `docs/`, plus the experimental "slipbox as agent memory" usage and a matching Near Term roadmap entry, linking `SYSTEM_PROMPT.md` as the source of truth.
- **style: remove em dashes from docs prose** — de-slops README, demo.md, SYSTEM_PROMPT.md. Code-block em dashes (verbatim prompts) left intact; large demo.md/SYSTEM_PROMPT.md line counts are formatter reflow, content verified identical.

All commits are non-releasing types (`docs:`/`style:`), so no version bump. Skills left untouched and in sync with source.

Merge intent: **rebase** (preserve the three commits), not squash.
